### PR TITLE
chore: add omit.js to deps

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "i18next": "^21.6.14",
     "lodash": "^4.17.21",
     "lodash.throttle": "^4.1.1",
+    "omit.js": "^2.0.2",
     "parse-github-url": "^1.0.2",
     "prism-react-renderer": "^1.1.1",
     "prismjs": "^1.21.0",


### PR DESCRIPTION
单独安装时会报没有 omit.js 的错。

在仓库中没有这个依赖而不报错，应该是因为 docz-theme-umi => antd^3 => omit 有依赖到。
![image](https://user-images.githubusercontent.com/35586469/163587529-9e2dd53b-526e-446b-b486-0518956335d0.png)

![image](https://user-images.githubusercontent.com/35586469/163588330-f1b815f9-7951-4565-bda9-6ecbc79d83a1.png)

