### PR TITLE
feat: i18n of examples page

### DIFF
--- a/.dumi/theme/layouts/DocLayout.tsx
+++ b/.dumi/theme/layouts/DocLayout.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useOutlet, useLocation } from 'dumi';
 import { Index } from './entry/Index';
 import { API } from './entry/API';
@@ -23,16 +24,27 @@ export default () => {
   const { pathname } = useLocation();
   const p = pathname.toLowerCase();
 
-  // // 首页
+  // @todo 南洋
+  // 做一些跳转，比如：/zh/examples/xxx -> /examples/xxx
+
+  // 首页
   if (p === '/' || p === '/en') return <Index />;
 
-  // // API 页面（docs 是兼容之前的 URL）
-  if (p.startsWith('/api') || p.startsWith('/en/api') || p.startsWith('/docs/en/api')) {
+  // API 页面
+  if (
+    p.startsWith('/api') || p.startsWith('/en/api') ||
+    // 这两个是兼容之前的
+    p.startsWith('/zh/docs/api') || p.startsWith('/en/docs/api') 
+  ) {
     return <API> {outlet} </API>
   }
 
-  // 教程页面（docs 是兼容之前的 URL）
-  if (p.startsWith('/manual') || p.startsWith('/en/manual') || p.startsWith('/docs/manual/')) {
+  // 教程页面
+  if (
+    p.startsWith('/manual') || p.startsWith('/en/manual') ||
+    // 这两个是兼容之前的
+    p.startsWith('/zh/docs/manual/') || p.startsWith('/en/docs/manual/')
+  ) {
     return <Manual> {outlet} </Manual>;
   }
 

--- a/.dumi/theme/pages/Example/index.tsx
+++ b/.dumi/theme/pages/Example/index.tsx
@@ -26,23 +26,23 @@ type ExampleParams = {
   /**
    * Example 的分类
    */
-  category: string;
+  topic: string;
   /**
    * Example 的名称
    */
-  name: string;
+  example: string;
 }
 
 /**
  * 具体单个案例的页面
  */
 const Example: React.FC<{}> = () => {
-  const { language, category, name } = useParams<ExampleParams>();
+  const { language = 'zh', topic, example } = useParams<ExampleParams>();
   const demo = location.hash.slice(1);
   /** 示例页面的元数据信息 */
   const { meta }: any = useContext(ThemeAntVContext);
   const { exampleTopics } = meta;
-  const demoInfo = getDemoInfo(exampleTopics, category, name, demo);
+  const demoInfo = getDemoInfo(exampleTopics, topic, example, demo);
 
   // 找不到，啥也别干了，404 页面
   if (!demoInfo) return <NotFound />;

--- a/.dumi/theme/pages/Examples/components/GalleryPageContent/index.tsx
+++ b/.dumi/theme/pages/Examples/components/GalleryPageContent/index.tsx
@@ -153,7 +153,7 @@ export const GalleryPageContent: React.FC<GalleryPageContentProps> = (props) => 
                   >
                     <Link
                       className={styles.galleryCardLink}
-                      to={`/${locale.id}/examples/${demoSlug}`}
+                      to={locale.id === 'zh' ? `/examples/${demoSlug}` : `/${locale.id}/examples/${demoSlug}`}
                     >
                       {demo.new ? (
                         <Badge.Ribbon

--- a/.dumi/theme/pages/Examples/index.tsx
+++ b/.dumi/theme/pages/Examples/index.tsx
@@ -1,3 +1,4 @@
+import React from 'react';
 import { useContext } from 'react';
 import { BackTop, Layout as AntLayout } from 'antd';
 import { Header } from '../../slots/Header';
@@ -31,7 +32,6 @@ const Example = () => {
   const { edges = [] } = allMarkdownRemark;
 
   const [prev, next] = usePrevAndNext();
-
 
   return (
     <>

--- a/.dumi/theme/slots/Header/index.tsx
+++ b/.dumi/theme/slots/Header/index.tsx
@@ -3,8 +3,7 @@ import React, { useState, useEffect } from 'react';
 import { useMedia } from 'react-use';
 import { useNavigate } from "react-router-dom";
 import cx from 'classnames';
-import { useSiteData } from 'dumi';
-
+import { useSiteData, useLocale } from 'dumi';
 import {
   GithubOutlined,
   MenuOutlined,
@@ -21,11 +20,13 @@ import { Products } from './Products';
 import { Navs, INav } from './Navs';
 import { Logo } from './Logo';
 import { LogoWhite } from './LogoWhite';
-import { useLocale } from 'dumi';
+import { getLangUrl } from './utils';
 
 import { useT } from '../hooks';
 
+
 import styles from './index.module.less';
+
 
 export type HeaderProps = {
   pathPrefix?: string;
@@ -305,20 +306,9 @@ const HeaderComponent: React.FC<HeaderProps> = ({
                     onLanguageChange(key.toString());
                     return;
                   }
-                  if (window.location.pathname == '/') {
-                    navigate('/en')
-                    return;
-                  }
-                  
-                  if (window.location.pathname.includes(`en`)) {
-                    navigate(
-                      window.location.pathname.replace(`/en`, ""),
-                    );
-                  } else {
-                    navigate(
-                      window.location.pathname.replace(`/`, "/en/"),
-                    );
-                  }
+
+                  const newUrl = getLangUrl(window.location.href, key);
+                  location.href = newUrl;
                 }}
               >
                 <Menu.Item key="en">

--- a/.dumi/theme/slots/Header/utils.ts
+++ b/.dumi/theme/slots/Header/utils.ts
@@ -1,0 +1,27 @@
+import URI from 'uri-parse';
+
+/*
+ * parse url like this
+ *
+ * schema://username:password@host:port/path?key=value#fragment;key=value
+ * \____/   \______/ \______/ \__/ \__/ \__/ \_______/ \______/ \______/
+ *   |         |        |       |    |    |      |         |       |
+ * schema      |     password   |   port  |    query    fragment   |
+ *          username          host      path                     extension
+ *
+ * note:
+ *   - username, password, port, path, query, fragment, extension is optional.
+ *   - scheme, host must be setting.
+ *   - username and password must be paired.
+ */
+
+export function getLangUrl(url: string, lang: string): string {
+  const uri = new URI(url);
+  if (uri.path.startsWith('en') || uri.path.startsWith('zh')) {
+    uri.path = uri.path.slice(3);
+  }
+
+  uri.path = lang === 'en' ? `en/${uri.path}` : uri.path;
+
+  return uri.toURI();
+}

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
     "react-slick": "^0.29.0",
     "react-split-pane": "^0.1.92",
     "react-use": "^17.4.0",
-    "slick-carousel": "^1.8.1"
+    "slick-carousel": "^1.8.1",
+    "uri-parse": "^1.0.0"
   },
   "devDependencies": {
     "@antv/data-set": "^0.11.8",

--- a/plugin.ts
+++ b/plugin.ts
@@ -16,23 +16,23 @@ export default (api: IApi) => {
   const pages = [
     // Examples gallery page.
     {
-      id: 'dumi-theme-antv-examples-zh',
+      id: 'dumi-theme-antv-example-list-zh',
       path: '/examples/',
       file: require.resolve('./.dumi/theme/pages/Examples/index.tsx'),
     },
     {
-      id: 'dumi-theme-antv-examples-lang',
+      id: 'dumi-theme-antv-example-list-lang',
       path: '/:language/examples/',
       file: require.resolve('./.dumi/theme/pages/Examples/index.tsx'),
     },
     // single example preview page.
     {
-      id: 'dumi-theme-antv-example-zh',
+      id: 'dumi-theme-antv-single-example-zh',
       path: '/examples/:topic/:example',
       file: require.resolve('./.dumi/theme/pages/Example/index.tsx'),
     },
     {
-      id: 'dumi-theme-antv-examples-lang',
+      id: 'dumi-theme-antv-single-example-lang',
       path: '/:language/examples/:topic/:example',
       file: require.resolve('./.dumi/theme/pages/Example/index.tsx'),
     },

--- a/plugin.ts
+++ b/plugin.ts
@@ -28,12 +28,12 @@ export default (api: IApi) => {
     // single example preview page.
     {
       id: 'dumi-theme-antv-example-zh',
-      path: '/examples/:category/:name',
+      path: '/examples/:topic/:example',
       file: require.resolve('./.dumi/theme/pages/Example/index.tsx'),
     },
     {
       id: 'dumi-theme-antv-examples-lang',
-      path: '/:language/examples/:category/:name',
+      path: '/:language/examples/:topic/:example',
       file: require.resolve('./.dumi/theme/pages/Example/index.tsx'),
     },
   ];

--- a/plugin.ts
+++ b/plugin.ts
@@ -16,13 +16,23 @@ export default (api: IApi) => {
   const pages = [
     // Examples gallery page.
     {
-      id: 'dumi-theme-antv-page-examples',
+      id: 'dumi-theme-antv-examples-zh',
+      path: '/examples/',
+      file: require.resolve('./.dumi/theme/pages/Examples/index.tsx'),
+    },
+    {
+      id: 'dumi-theme-antv-examples-lang',
       path: '/:language/examples/',
       file: require.resolve('./.dumi/theme/pages/Examples/index.tsx'),
     },
     // single example preview page.
     {
-      id: 'dumi-theme-antv-page-example',
+      id: 'dumi-theme-antv-example-zh',
+      path: '/examples/:category/:name',
+      file: require.resolve('./.dumi/theme/pages/Example/index.tsx'),
+    },
+    {
+      id: 'dumi-theme-antv-examples-lang',
       path: '/:language/examples/:category/:name',
       file: require.resolve('./.dumi/theme/pages/Example/index.tsx'),
     },


### PR DESCRIPTION
- [x] example 页面的国际化跳转
- [x] 切换语言，没有保留 hash 信息
- [x] 如果带有 /zh/ 的路径，切换的时候，会变成 /en/zh