### PR TITLE
refactor: use passive code block mode

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -5,6 +5,13 @@ import { myResolve } from './utils';
 export default (api: IApi) => {
   api.describe({ key: `dumi-theme:${require('../../package.json').name}` });
 
+  // use passive mode for code blocks of markdown, to avoid dumi compile theme as react component
+  api.modifyDefaultConfig((memo) => {
+    memo.resolve.codeBlockMode = 'passive';
+
+    return memo;
+  });
+
   const pages = [
     // Examples gallery page.
     {


### PR DESCRIPTION
dumi 默认会把 jsx 代码块编译为 React 组件，所以在插件层默认使用代码块的被动渲染模式，禁用 dumi 的默认行为、避免编译报错