### PR TITLE
fix: sidebar render error beacuse docs.slug config case up and lower

### DIFF
--- a/src/slots/ManualContent/index.tsx
+++ b/src/slots/ManualContent/index.tsx
@@ -95,7 +95,7 @@ export const ManualContent: React.FC<ManualContent> = ({ children }) => {
     function fullSidebarDataToMenuData(rootList: SidebarData, hrefId: string, list: SidebarData) {
       // 递归
       rootList.forEach((item: MenuItem) => {
-        const href = !baseRoute.startsWith('/en') ? `/${item.slug}` : `/en/${item.slug}`
+        const href = (!baseRoute.startsWith('/en') ? `/${item.slug}` : `/en/${item.slug}`).toLocaleLowerCase()
         const id = href.split("/").slice(0, href.split("/").length - 1).join("/")
         if (href.includes(baseRoute)) {
           if (id === hrefId) {


### PR DESCRIPTION
docs.slug配置区分大小写导致丢失二级菜单