### PR TITLE
Fix the missing Weibo icon at the bottom

### DIFF
--- a/src/slots/_.less
+++ b/src/slots/_.less
@@ -10,7 +10,7 @@
 
   @media only screen and (max-width: 931.99px) {
     & {
-      max-width: calc(100% - 60px);
+      max-width: calc(100% - 80px);
     }
   }
 


### PR DESCRIPTION
底部微博图标在宽度缩小到900px时，会出现不正常缺失，所以更改了底部容器的最大宽度，使图标内移
- fix https://github.com/antvis/G6/issues/4055