### PR TITLE
fix: moving end overflow hidden issue

### DIFF
--- a/src/slots/Banner/index.module.less
+++ b/src/slots/Banner/index.module.less
@@ -363,7 +363,7 @@
       width: 100%;
       display: block;
       bottom: 20px;
-      height: 44px;
+      height: 48px;
       overflow: hidden;
     }
 


### PR DESCRIPTION
### 问题描述
- fix https://github.com/antvis/G6/issues/4057
G6官网首页Notification版本在移动端出现底部被遮盖现象
![image](https://user-images.githubusercontent.com/71303732/202204719-9be06e0d-fab8-4c8e-a296-7f154c449e57.png)

### 解决策略
在媒体查询适配宽度小于900px的类名为notifications的标签样式里修改height属性，由原先的44px改为48px
追究根本原因是其内部类名为date的标签存在margin-top: 4px，也可以删除其解决，但由于会改变pc端样式，因此我采取在媒体查询中修改
