### PR TITLE
refactor: handle hash change for scroll

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/dumi-theme-antv",
-  "version": "0.3.3",
+  "version": "0.3.4",
   "description": "AntV website theme based on dumi2.",
   "types": "dist/types.d.ts",
   "scripts": {

--- a/src/layouts/DocLayout.tsx
+++ b/src/layouts/DocLayout.tsx
@@ -11,7 +11,7 @@ import '../slots/_.less';
  * DocuLayout 是 dumi2 的内置 layout 入口，在这里使用页面路径进行区分成自己不同的 Layout。
  */
 export default () => {
-  const { themeConfig } = useSiteData();
+  const { themeConfig, loading } = useSiteData();
   const {
     navs
   } = themeConfig;
@@ -25,7 +25,20 @@ export default () => {
   }, []);
 
   const outlet = useOutlet();
-  const { pathname } = useLocation();
+  const { pathname, hash } = useLocation();
+
+  // 监听 hash 变更，跳转到锚点位置
+  // 同时监听页面 loading 状态，因为路由按需加载时需要等待页面渲染完毕才能找到锚点位置
+  useEffect(() => {
+    const id = hash.replace('#', '');
+
+    if (id) {
+      const elm = document.getElementById(decodeURIComponent(id));
+
+      if (elm) document.documentElement.scrollTo(0, elm.offsetTop - 80);
+    }
+  }, [loading, hash]);
+
   const path = pathname
   // 统一去掉中英文前缀
   let p = path.replace('/zh/', '/').replace('/en/', '/');
@@ -33,14 +46,14 @@ export default () => {
   if (p === '/' || p === '/zh' || p === '/en' || p === '/en/') return <Index />;
 
   // 匹配 navs 中的 docs 路由
-  const docsRoutes = 
+  const docsRoutes =
     navs
     .filter(nav => nav.slug && nav.slug.startsWith('docs/'))
     .map(nav => nav.slug && nav.slug.split('/').find(item => item !== 'docs'));
 
   if (docsRoutes.some(route => p.startsWith(`/${route}`) || p.startsWith(`/docs/${route}`))) {
-    return <Manual>{outlet}</Manual>      
+    return <Manual>{outlet}</Manual>
   }
-  
+
   return outlet;
 };


### PR DESCRIPTION
给 DocLayout 加上 hash 监听，以处理 TOC 的锚点点击及带 hash 的页面 URL 访问，确保能跳转到正确的位置

为什么之前不需要加？因为之前的跳转逻辑是放在 dumi 内部的页面组件里的，但在全定制主题且自己处理了锚点跳转（比如 antd）的情况下，跳转逻辑就会冲突，所以 dumi 把跳转逻辑挪到了默认主题的 DocLayout 里，与 TOC 结合使用逻辑上也更加合理；但这意味着只覆盖 DocLayout 时且仍使用默认主题 TOC（比如 AntV）的情况，就需要额外处理 hash 监听逻辑