### PR TITLE
[WIP] refactor: disable force kebab-case routing

### DIFF
--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -11,7 +11,7 @@ export default (api: IApi) => {
     memo.resolve.codeBlockMode = 'passive';
     
     // disable force kebab-case routing, respect naming from file system
-    memo.resolve.forceKebabCaseRoutes = false;
+    memo.resolve.forceKebabCaseRouting = false;
 
     // add exportStatic .html
     memo.exportStatic.extraRoutePaths = getExamplePaths();

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -9,6 +9,9 @@ export default (api: IApi) => {
   api.modifyDefaultConfig((memo) => {
     // use passive mode for code blocks of markdown, to avoid dumi compile theme as react component
     memo.resolve.codeBlockMode = 'passive';
+    
+    // disable force kebab-case routing, respect naming from file system
+    memo.resolve.forceKebabCaseRoutes = false;
 
     // add exportStatic .html
     memo.exportStatic.extraRoutePaths = getExamplePaths();


### PR DESCRIPTION
默认禁用 dumi 的强制短横线路由，因为 AntV 一直使用的是驼峰路由，dumi 在前几个版本改成默认短横线路由，引发 Breaking Change 导致部分文档路由匹配失败，所以新增了一个配置项来关闭该行为