### PR TITLE
fix(compile): specify decoratorsBeforeExport option for stage-3 preset

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/dumi-theme-antv",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "AntV website theme based on dumi2.",
   "types": "dist/types.d.ts",
   "scripts": {

--- a/src/slots/CodeEditor/utils.ts
+++ b/src/slots/CodeEditor/utils.ts
@@ -181,9 +181,8 @@ try {
 export function compile(value: string, relativePath: string) {
   const { code } = transform(value, {
     filename: relativePath,
-    presets: ['react', 'typescript', 'es2015', 'stage-3'],
+    presets: ['react', 'typescript', 'es2015', ['stage-3', { decoratorsBeforeExport: true }]],
     plugins: ['transform-modules-umd'],
-    
   });
   return code;
 }


### PR DESCRIPTION
# 官网案例跑不起来

![image](https://user-images.githubusercontent.com/49330279/222326486-63e26780-72d2-499b-8f5a-9d1a06ceab7d.png)

## 出现原因

官网案例编译过程中的一个 babel preset: stage-3（支持装饰器语法） 一个配置是必须的。这个配置是 [decoratorsBeforeExport](https://babeljs.io/docs/babel-plugin-proposal-decorators#decoratorsbeforeexport)，大概的含义如下：

![image](https://user-images.githubusercontent.com/49330279/222326931-875b4f62-c798-4502-8e64-57068d3602a1.png)

## 解决办法

将 decoratorsBeforeExport 设置为 `true`，最后效果如下：

![image](https://user-images.githubusercontent.com/49330279/222327643-644ca765-6e62-4b98-93f8-2eb9d7cb1ec1.png)

