### PR TITLE
fix: new Image in Promise will cause 100% cpu usage

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/dumi-theme-antv",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "AntV website theme based on dumi2.",
   "types": "dist/types.d.ts",
   "scripts": {

--- a/src/slots/utils.ts
+++ b/src/slots/utils.ts
@@ -15,16 +15,7 @@ export async function ping(): Promise<Status> {
     'objects.alip' +
     'ay.com/alip' +
     'ay-rmsdeploy-image/rmsportal/RKuAiriJqrUhyqW.png';
-    const img = new Image();
-    img.onload = () => {
-      img.src = '';
-      resolve('responded');
-    };
-    img.onerror = () => {
-      img.src = '';
-      resolve('error');
-    };
-    img.src = url;
+    fetch(url).then((resp) => resolve(resp.status === 200 ? 'responded' : 'error'))
   });
 
   return Promise.race([timeout, network]);


### PR DESCRIPTION
代码中 image load 之后修改了 src，又带来下一次的事件，带来死循环，改成用 fetch。

![image](https://user-images.githubusercontent.com/7856674/231369632-4ab960f3-ea81-4f21-9c43-bdedd9de7b02.png)
