### PR TITLE
feat: support spec tab

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,7 @@
+{
+  "semi": true,
+  "singleQuote": true,
+  "trailingComma": "all",
+  "bracketSpacing": true,
+  "arrowParens": "always"
+}

--- a/example/.dumi/global.ts
+++ b/example/.dumi/global.ts
@@ -1,7 +1,72 @@
-
 /**
  * 增加自己的全局变量，用于 DEMO 中的依赖，以 G2 为例
  */
 if (window) {
-  (window as any).g2 = require('@antv/g2/lib/index.js');
+  (window as any).g2 = extendG2(require('@antv/g2/lib/index.js'));
+}
+
+// 对 G2 的 Chart 对象进行扩展
+// 1. 可以自定义 spec 的展示内容和 key 的排序
+// 2. 在 render 的时候触发 spec 事件抛出 spec，用于展示 spec
+function extendG2(g2) {
+  const { Chart: G2Chart, ...rest } = g2;
+
+  // 这里只是对顶层 key 进行排序，在 G2 中还需要递归排序
+  const sortKeys = (options) => {
+    const newOptions = sortObject(options);
+    return newOptions;
+  };
+
+  const sortObject = (
+    obj,
+    keys = [
+      'type',
+      'autoFit',
+      'theme',
+      'width',
+      'height',
+      'data',
+      'encode',
+      'transform',
+      'scale',
+      'coordinate',
+      'axis',
+      'legend',
+      'label',
+      'children',
+    ].reverse(),
+  ) => {
+    const autoFit = Object.keys(obj).find((d) => d === 'autoFit');
+    const filter = ([key, _]) =>
+      !autoFit ? true : key === 'width' || key === 'height' ? false : true;
+    return Object.fromEntries(
+      Object.entries(obj)
+        .sort(([a], [b]) => keys.indexOf(b) - keys.indexOf(a))
+        .filter(filter),
+    );
+  };
+
+  class Chart extends G2Chart {
+    options() {
+      if (arguments.length !== 0) return super.options(...arguments);
+      const options = super.options();
+      const { type, children = [], key, ...rest } = options;
+      const topLevel =
+        type === 'view' && children.length === 1
+          ? { ...children[0], ...rest }
+          : { type, children, ...rest };
+      return sortKeys(topLevel);
+    }
+    render() {
+      // 触发自定义事件
+      const event = new CustomEvent('spec', {
+        detail: {
+          options: this.options(),
+        },
+      });
+      window.dispatchEvent(event);
+      return super.render();
+    }
+  }
+  return { ...rest, Chart };
 }

--- a/example/.dumirc.ts
+++ b/example/.dumirc.ts
@@ -23,8 +23,10 @@ export default defineConfig({
     showLanguageSwitcher: true,                                         // 是否显示官网语言切换
     showWxQrcode: true,                                                 // 是否显示头部菜单的微信公众号
     showChartResize: true,                                              // 是否在 demo 页展示图表视图切换
-    showAPIDoc: true,                                                   // 是否在 demo 页展示API文档
+    showAPIDoc: true,   
+    showSpecTab: true,                                                // 是否在 demo 页展示API文档
     themeSwitcher: 'g2',
+    es5: false,
     version,
     versions: {                                                         // 历史版本以及切换下拉菜单
       '0.3.x': 'https://g.antv.vision/',

--- a/example/examples/case/area/demo/interval.ts
+++ b/example/examples/case/area/demo/interval.ts
@@ -11,6 +11,7 @@ const data = [
 const chart = new Chart({
   container: 'container',
   autoFit: true,
+  theme: 'classic'
 });
 
 chart

--- a/example/examples/case/bar/demo/bar1.ts
+++ b/example/examples/case/bar/demo/bar1.ts
@@ -1,30 +1,20 @@
 import { Chart } from '@antv/g2';
 
-const text =
-  `This Is Just To Say\nWilliam Carlos Williams, 1934\n\nI have eaten\nthe plums\nthat were in\nthe icebox\n\nand which\nyou were probably\nsaving\nfor breakfast\n\nForgive me\nthey were delicious\nso sweet\nand so cold`.split(
-    '\n',
-  );
-
 const chart = new Chart({
   container: 'container',
+  theme: 'classic',
   autoFit: true,
 });
 
-chart.data(text);
-
 chart
-  .text()
-  .encode('x', 0.5)
-  .encode('y', (_, idx) => idx)
-  .encode('text', (v) => v)
-  // .encode('color', (v) => v)
-  .scale('x', { domain: [0, 1] })
-  .scale('y', { type: 'band' })
-  .style('textAlign', 'center')
-  .style('textBaseline', 'middle')
-  .style('fontSize', 16)
-  .style('opacity', (_, idx, arr) => idx / arr.length + 0.3)
-  .axis(false)
-  .legend(false);
+  .interval()
+  .data({
+    type: 'fetch',
+    value:
+      'https://gw.alipayobjects.com/os/bmw-prod/fb9db6b7-23a5-4c23-bbef-c54a55fee580.csv',
+  })
+  .encode('x', 'letter')
+  .encode('y', (d) => d.frequency)
+  .axis('y', { labelFormatter: '.0%', title: 'frequency' });
 
 chart.render();

--- a/example/examples/case/bar/demo/bar2.ts
+++ b/example/examples/case/bar/demo/bar2.ts
@@ -1,12 +1,15 @@
 import { Chart } from '@antv/g2';
 
-fetch('https://gw.alipayobjects.com/os/bmw-prod/1d565782-dde4-4bb6-8946-ea6a38ccf184.json')
+fetch(
+  'https://gw.alipayobjects.com/os/bmw-prod/1d565782-dde4-4bb6-8946-ea6a38ccf184.json',
+)
   .then((res) => res.json())
-  .then((data) => data.map(d => ({...d, 'Date': new Date(d.Date)})))
+  .then((data) => data.map((d) => ({ ...d, Date: new Date(d.Date) })))
   .then((data) => {
     const chart = new Chart({
       container: 'container',
       autoFit: true,
+      theme: 'classic',
     });
 
     chart
@@ -19,4 +22,3 @@ fetch('https://gw.alipayobjects.com/os/bmw-prod/1d565782-dde4-4bb6-8946-ea6a38cc
 
     chart.render();
   });
-

--- a/package.json
+++ b/package.json
@@ -61,6 +61,7 @@
     "antd": "^4.23.5",
     "classnames": "^2.3.2",
     "codesandbox": "^2.2.3",
+    "d3-dsv": "^3.0.1",
     "docsearch.js": "^2.6.3",
     "front-matter": "^4.0.2",
     "fs-extra": "^10.1.0",

--- a/src/pages/Example/index.tsx
+++ b/src/pages/Example/index.tsx
@@ -1,23 +1,23 @@
-import React, { useContext, useEffect, useState } from 'react';
-import { useParams, useLocation, useNavigate } from 'react-router-dom';
-import { get } from 'lodash-es';
 import { Layout } from 'antd';
 import { useLocale, useSiteData } from 'dumi';
-import { SEO } from '../../slots/SEO';
-import { Header } from '../../slots/Header';
-import { ExampleSider } from '../../slots/ExampleSider';
+import { get } from 'lodash-es';
+import React, { useContext, useEffect, useState } from 'react';
+import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { ThemeAntVContext } from '../../context';
 import { CodeRunner } from '../../slots/CodeRunner';
 import { getDemoInfo } from '../../slots/CodeRunner/utils';
-import { ThemeAntVContext } from '../../context';
-import { ExampleTopic, Demo } from '../../types';
+import { ExampleSider } from '../../slots/ExampleSider';
+import { Header } from '../../slots/Header';
+import { SEO } from '../../slots/SEO';
+import { Demo, ExampleTopic } from '../../types';
 import styles from './index.module.less';
 import { getCurrentTitle } from './utils';
 
 const { Sider, Content } = Layout;
 
 type title = {
-  [key: string]: string
-}
+  [key: string]: string;
+};
 type ExampleParams = {
   /**
    * 多语言
@@ -44,7 +44,7 @@ const Example: React.FC = () => {
   /** 示例页面的元数据信息 */
   const metaData: any = useContext(ThemeAntVContext);
   const locale = useLocale();
-  const { themeConfig } = useSiteData()
+  const { themeConfig } = useSiteData();
 
   const exampleTopics: ExampleTopic[] = metaData.meta.exampleTopics;
   const demo = hash.slice(1);
@@ -53,13 +53,13 @@ const Example: React.FC = () => {
 
   const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
 
-  const [title, setTitle] = useState<title>({})
-  
+  const [title, setTitle] = useState<title>({});
+
   useEffect(() => {
     if (topic && example && demo) {
       const targetDemoInfo = getDemoInfo(exampleTopics, topic, example, demo);
       setCurrentDemo(targetDemoInfo);
-      setTitle(getCurrentTitle(exampleTopics, topic, example))
+      setTitle(getCurrentTitle(exampleTopics, topic, example));
     }
   }, [topic, example, hash]);
   return (
@@ -74,7 +74,7 @@ const Example: React.FC = () => {
           collapsible
           collapsed={isCollapsed}
           className={styles.menuSider}
-          theme='light'
+          theme="light"
         >
           {currentDemo && (
             <ExampleSider

--- a/src/slots/CodeEditor/Toolbar.tsx
+++ b/src/slots/CodeEditor/Toolbar.tsx
@@ -1,17 +1,20 @@
-import React, { useEffect, useState } from 'react';
 import {
   CodeSandboxOutlined,
   PlayCircleOutlined,
   ThunderboltOutlined,
-  FullscreenExitOutlined,
-  FullscreenOutlined,
 } from '@ant-design/icons';
-import { Typography, Tooltip } from 'antd';
-import { useLocale, FormattedMessage } from 'dumi';
-import { getParameters } from 'codesandbox/lib/api/define';
 import stackblitzSdk from '@stackblitz/sdk';
+import { Tooltip, Typography } from 'antd';
+import { getParameters } from 'codesandbox/lib/api/define';
+import { FormattedMessage, useLocale } from 'dumi';
+import React, { useEffect, useState } from 'react';
 import { ping } from '../utils';
-import { extractImportDeps, getCodeSandboxConfig, getStackblitzConfig, getRiddleConfig } from './utils';
+import {
+  extractImportDeps,
+  getCodeSandboxConfig,
+  getRiddleConfig,
+  getStackblitzConfig,
+} from './utils';
 
 import styles from './Toolbar.module.less';
 
@@ -19,6 +22,7 @@ const { Paragraph } = Typography;
 
 export enum EDITOR_TABS {
   JAVASCRIPT = 'JavaScript',
+  SPEC = 'Spec',
   DATA = 'Data',
 }
 
@@ -36,9 +40,9 @@ type ToolbarProps = {
    */
   title:
     | {
-    zh?: string;
-    en?: string;
-  }
+        zh?: string;
+        en?: string;
+      }
     | string;
   location?: Location;
   /**
@@ -83,7 +87,7 @@ type ToolbarProps = {
    * 执行代码
    */
   onExecuteCode: () => void;
-}
+};
 
 export const Toolbar: React.FC<ToolbarProps> = ({
   sourceCode,
@@ -99,8 +103,9 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   onExecuteCode,
 }) => {
   const locale = useLocale();
-  const exampleTitle =
-    (typeof title === 'object' ? title[locale.id as 'zh' | 'en'] : title) as string;
+  const exampleTitle = (
+    typeof title === 'object' ? title[locale.id as 'zh' | 'en'] : title
+  ) as string;
 
   // 使用 playground.dependencies 定义的版本号
   const dependencies = {
@@ -109,9 +114,30 @@ export const Toolbar: React.FC<ToolbarProps> = ({
   };
   const devDependencies = playground.devDependencies || {};
 
-  const codeSandboxConfig = getCodeSandboxConfig(exampleTitle, sourceCode, fileExtension, dependencies, devDependencies, playground);
-  const riddlePrefillConfig = getRiddleConfig(exampleTitle, sourceCode, fileExtension, dependencies, devDependencies, playground);
-  const stackblitzPrefillConfig = getStackblitzConfig(exampleTitle, sourceCode, fileExtension, dependencies, devDependencies, playground);
+  const codeSandboxConfig = getCodeSandboxConfig(
+    exampleTitle,
+    sourceCode,
+    fileExtension,
+    dependencies,
+    devDependencies,
+    playground,
+  );
+  const riddlePrefillConfig = getRiddleConfig(
+    exampleTitle,
+    sourceCode,
+    fileExtension,
+    dependencies,
+    devDependencies,
+    playground,
+  );
+  const stackblitzPrefillConfig = getStackblitzConfig(
+    exampleTitle,
+    sourceCode,
+    fileExtension,
+    dependencies,
+    devDependencies,
+    playground,
+  );
   // const htmlCode = getHtmlCodeTemplate(exampleTitle, sourceCode, fileExtension, dependencies, devDependencies, playground);
 
   const [riddleVisible, updateRiddleVisible] = useState(false);
@@ -135,19 +161,19 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       </div>
       {riddleVisible ? (
         <form
-          action='//riddle.alibaba-inc.com/riddles/define'
-          method='POST'
-          target='_blank'
+          action="//riddle.alibaba-inc.com/riddles/define"
+          method="POST"
+          target="_blank"
         >
           <input
-            type='hidden'
-            name='data'
+            type="hidden"
+            name="data"
             value={JSON.stringify(riddlePrefillConfig)}
           />
           <Tooltip title={<FormattedMessage id="在 Riddle 中打开" />}>
             <input
-              type='submit'
-              value='Create New Riddle with Prefilled Data'
+              type="submit"
+              value="Create New Riddle with Prefilled Data"
               className={styles.riddle}
             />
           </Tooltip>
@@ -163,16 +189,16 @@ export const Toolbar: React.FC<ToolbarProps> = ({
       </Tooltip>
       <Tooltip title={<FormattedMessage id="在 CodeSandbox 中打开" />}>
         <form
-          action='https://codesandbox.io/api/v1/sandboxes/define'
-          method='POST'
-          target='_blank'
+          action="https://codesandbox.io/api/v1/sandboxes/define"
+          method="POST"
+          target="_blank"
         >
           <input
-            type='hidden'
-            name='parameters'
+            type="hidden"
+            name="parameters"
             value={getParameters(codeSandboxConfig)}
           />
-          <button type='submit' className={styles.codesandbox}>
+          <button type="submit" className={styles.codesandbox}>
             <CodeSandboxOutlined style={{ marginLeft: 8 }} />
           </button>
         </form>

--- a/src/slots/CodeEditor/index.tsx
+++ b/src/slots/CodeEditor/index.tsx
@@ -1,13 +1,15 @@
-import ReactDOM from 'react-dom';
-import React, { useRef, useState, useCallback, useEffect } from 'react';
 import MonacoEditor, { loader } from '@monaco-editor/react';
-import { useSiteData, useLocale } from 'dumi';
+import { autoType as d3AutoType, dsvFormat } from 'd3-dsv';
+import { useLocale, useSiteData } from 'dumi';
 import { debounce, noop } from 'lodash-es';
+import { format } from 'prettier';
+import parserBabel from 'prettier/parser-babel';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
 import { bind, clear } from 'size-sensor';
-import { replaceInsertCss, execute, compile } from './utils';
-import { Toolbar, EDITOR_TABS } from './Toolbar';
 import { Loading } from '../Loading';
+import { EDITOR_TABS, Toolbar } from './Toolbar';
 import styles from './index.module.less';
+import { compile, execute, replaceInsertCss } from './utils';
 
 loader.config({
   'vs/nls': {
@@ -76,7 +78,7 @@ export type CodeEditorProps = {
     };
     htmlCodeTemplate?: string;
   };
-}
+};
 
 /**
  * 代码编辑器
@@ -94,15 +96,19 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   onError = noop,
   onFullscreen = noop,
 }) => {
-  const locale = useLocale()
-  const { extraLib = '' } = useSiteData().themeConfig.playground;
+  const locale = useLocale();
+  const { themeConfig } = useSiteData();
+  const { es5 = true, showSpecTab = false } = themeConfig;
+  const { extraLib = '' } = themeConfig.playground;
   // 编辑器两个 tab，分别是代码和数据
   const [data, setData] = useState(null);
+  const [spec, setSpec] = useState(null);
   const [code, setCode] = useState(source);
   // monaco instance
   const monacoRef = useRef<any>(null);
   // 文件后缀
-  const fileExtension = relativePath.split('.')[relativePath.split('.').length - 1] || 'js';
+  const fileExtension =
+    relativePath.split('.')[relativePath.split('.').length - 1] || 'js';
   // 菜单栏
   const [editorTabs, setEditorTabs] = useState<EDITOR_TABS[]>([]);
   // 当前选中菜单栏
@@ -127,14 +133,14 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
       onError(null);
     }
   }, []);
-  
+
   useEffect(() => {
     // 用于上报错误信息，使用 script 执行代码
     if (typeof window !== 'undefined') {
       // Cath error of code.
       (window as any).__reportErrorInPlayground = reportError;
       // Catch error of timeout/raf.
-      window.onerror = reportError
+      window.onerror = reportError;
       // Catch error of  promise.
       window.addEventListener('unhandledrejection', reportError);
     }
@@ -144,28 +150,62 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
         window.onerror = undefined;
         window.removeEventListener('unhandledrejection', reportError);
       }
-    }
+    };
   }, []);
 
-  const executeCode = useCallback(debounce((v: string) => {
-    if (currentEditorTab !== EDITOR_TABS.JAVASCRIPT) return;
-    if (!v) return;
-    
-    // 1. 先编译代码
-    let compiled;
-    try {
-      compiled = compile(replaceInsertCss(v, locale.id), relativePath);
-    } catch (e) {
-      reportError(e);
-      // 执行出错，后面的步骤不用做了！
-      return;
+  const executeCode = useCallback(
+    debounce((v: string) => {
+      if (currentEditorTab !== EDITOR_TABS.JAVASCRIPT) return;
+      if (!v) return;
+
+      // 1. 先编译代码
+      let compiled;
+      try {
+        compiled = compile(replaceInsertCss(v, locale.id), relativePath, es5);
+      } catch (e) {
+        reportError(e);
+        // 执行出错，后面的步骤不用做了！
+        return;
+      }
+
+      // 2. 执行代码，try catch 在内部已经做了
+      execute(
+        compiled,
+        containerId,
+        playground?.container as string,
+        replaceId,
+      );
+
+    }, 300),
+    [exampleId, currentEditorTab],
+  );
+
+  const updateData = (data) => {
+    if (!data) return;
+    const tabs = showSpecTab
+      ? [EDITOR_TABS.JAVASCRIPT, EDITOR_TABS.SPEC, EDITOR_TABS.DATA]
+      : [EDITOR_TABS.JAVASCRIPT, EDITOR_TABS.DATA];
+    setEditorTabs(tabs);
+    setData(data);
+  };
+
+  // 找到 spec 里面的 online data 并且更新它
+  const updateDataFromSpec = (options) => {
+    if (!options) return;
+    const discoverd = [options];
+    const dataList = [];
+    while (discoverd.length) {
+      const node = discoverd.pop();
+      const { data } = node;
+      if (typeof data === 'object' && data.type === 'fetch') {
+        dataList.push(data);
+      }
+      discoverd.push(...(node.children || []));
     }
+    fetchData(dataList.map((d) => d.value)).then(updateData);
+  };
 
-    // 2. 执行代码，try catch 在内部已经做了
-    execute(compiled, containerId, playground?.container as string, replaceId);
-  }, 300), [exampleId, currentEditorTab]);
-
-  // 案例变化的时候，修改期待吗
+  // 案例变化的时候，修改代码
   useEffect(() => {
     setCode(source);
   }, [exampleId]);
@@ -178,9 +218,12 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   useEffect(() => {
     const dom = document.getElementById(containerId);
     if (dom) {
-      bind(dom, debounce(() => {
-        dispatchResizeEvent();
-      }, 100));
+      bind(
+        dom,
+        debounce(() => {
+          dispatchResizeEvent();
+        }, 100),
+      );
     }
     return () => {
       dom && clear(dom);
@@ -201,25 +244,69 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
     };
   }, []);
 
+  // fetch 多份远程数据，如果有多份合并成一份。
+  const fetchData = async (urls) => {
+    const parseCSV = (response) => {
+      return response.text().then((text) => {
+        return dsvFormat(',').parse(text, d3AutoType);
+      });
+    };
+    const parseJSON = (response) => response.json();
+    const dataList = await Promise.all(
+      urls.map((url) =>
+        fetch(url).then((response) => {
+          const format = url.split('.').pop();
+          if (format === 'csv') return parseCSV(response);
+          return parseJSON(response);
+        }),
+      ),
+    );
+    if (dataList.length <= 1) return dataList[0];
+    return Object.fromEntries(urls.map((url, index) => [url, dataList[index]]));
+  };
+
+  // 切换 example 的时候，切换到代码编辑页面
+  // 用于更新当前 example 的 spec 和 data
+  useEffect(() => {
+    setCurrentEditorTab(EDITOR_TABS.JAVASCRIPT);
+  }, [exampleId]);
+
   // hook 用户的数据
   useEffect(() => {
-    const dataFileMatch = source.match(/fetch\('(.*)'\)/);
+    // 需要匹配首位的换行符，以及 ' 和 "
+    const dataFileMatch = source.match(/fetch\(\s*["|'](.*)["|']\s*\)/);
     if (dataFileMatch && dataFileMatch.length > 0) {
-      fetch(dataFileMatch[1])
-        .then((response) => response.json())
-        .then((data) => {
-          setEditorTabs([EDITOR_TABS.JAVASCRIPT, EDITOR_TABS.DATA]);
-          setData(data);
-        });
+      fetchData([dataFileMatch[1].trim()]).then((data) => {
+        updateData(data);
+      });
     } else {
-      setEditorTabs([EDITOR_TABS.JAVASCRIPT]);
+      const tabs = showSpecTab
+        ? [EDITOR_TABS.JAVASCRIPT, EDITOR_TABS.SPEC]
+        : [EDITOR_TABS.JAVASCRIPT];
+      setEditorTabs(tabs);
     }
   }, [exampleId]);
 
+  // 监听更新 spec 的事件，这是一个定义事件，需要在 .dumi/global.ts 里面 dispatch
+  useEffect(() => {
+    const update = (e) => {
+      const { options } = e.detail as any;
+      setSpec(options);
+      updateDataFromSpec(options);
+    };
+    window.addEventListener('spec', update);
+    return () => {
+      window.removeEventListener('spec', update);
+    };
+  });
+
   // 切换 tab
-  const onTabChange = useCallback((tab) => {
-    setCurrentEditorTab(tab);
-  }, [exampleId]);
+  const onTabChange = useCallback(
+    (tab) => {
+      setCurrentEditorTab(tab);
+    },
+    [exampleId],
+  );
 
   // useEffect(() => {
   //   if (monacoRef.current) {
@@ -228,11 +315,65 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
   //   }
   // }, [currentEditorTab]);
 
-  const onCodeChange = useCallback((value: string, event) => {
-    if (!event.isFlush && currentEditorTab === EDITOR_TABS.JAVASCRIPT) {
-      setCode(value)
+  const onCodeChange = useCallback(
+    (value: string, event) => {
+      if (!event.isFlush && currentEditorTab === EDITOR_TABS.JAVASCRIPT) {
+        setCode(value);
+      }
+    },
+    [currentEditorTab],
+  );
+
+  const parseFunction = (string) => {
+    return string.replace(/"\<func\>(.*)\<\/func\>"/g, (_, code) => code);
+  };
+
+  // 序列化 JavaScript 对象的时候对 function 进行特殊的标注，
+  // 使得解析该字符串的时候能方便的提取 function 对应的字符串。
+  // { add: (x, y) => x + y } => '{ add: <func>(x, y) => x + y</func> }'
+  const withFunction = (_: string, value: any) => {
+    if (typeof value !== 'function') return value;
+    return `<func>${value.toString().replace(/\n/g, '')}</func>`;
+  };
+
+  const languageOf = (tab) => {
+    switch (tab) {
+      case EDITOR_TABS.JAVASCRIPT:
+      case EDITOR_TABS.SPEC:
+        return 'javascript';
+      case EDITOR_TABS.DATA:
+        return 'json';
+      default:
+        return 'javascript';
     }
-  }, [currentEditorTab]);
+  };
+
+  const valueOf = (tab) => {
+    switch (tab) {
+      case EDITOR_TABS.JAVASCRIPT:
+        return code;
+      case EDITOR_TABS.SPEC:
+        return format(
+          parseFunction(`(${JSON.stringify(spec, withFunction)})`),
+          {
+            plugins: [parserBabel],
+          },
+        );
+      case EDITOR_TABS.DATA:
+        return JSON.stringify(data, null, 2);
+      default:
+        return null;
+    }
+  };
+
+  const defaultOf = (tab) => {
+    switch (tab) {
+      case EDITOR_TABS.JAVASCRIPT:
+        return code;
+      default:
+        return null;
+    }
+  };
 
   return (
     <div className={styles.editor}>
@@ -249,36 +390,38 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
         onEditorTabChange={onTabChange}
         onToggleFullscreen={onFullscreen}
       />
-      <div
-        className={styles.monaco}
-        style={{ height: 'calc(100% - 36px)' }}
-      >
-        <MonacoEditor
-          language={
-            currentEditorTab === EDITOR_TABS.JAVASCRIPT ? 'javascript' : 'json'
-          }
-          value={currentEditorTab === EDITOR_TABS.JAVASCRIPT ? code : JSON.stringify(data, null, 2)}
-          // defaultValue={code}
-          path={relativePath}
-          loading={<Loading />}
-          options={{
-            readOnly: currentEditorTab === EDITOR_TABS.DATA,
-            automaticLayout: true,
-            minimap: {
-              enabled: false,
-            },
-            scrollBeyondLastLine: false,
-            fixedOverflowWidgets: true,
-            lineNumbersMinChars: 4,
-            showFoldingControls: 'always',
-            foldingHighlight: true,
+      {editorTabs.map((tab) => (
+        <div
+          key={tab}
+          className={styles.monaco}
+          style={{
+            height: 'calc(100% - 36px)',
+            display: tab === currentEditorTab ? 'block' : 'none',
           }}
-          onChange={onCodeChange}
-          onMount={(editor: any) => {
-            monacoRef.current = editor;          
-          }}
-        />
-      </div>
+        >
+          <MonacoEditor
+            language={languageOf(tab)}
+            value={valueOf(tab)}
+            defaultValue={defaultOf(tab)}
+            path={tab}
+            loading={<Loading />}
+            options={{
+              readOnly: tab === EDITOR_TABS.DATA || tab === EDITOR_TABS.SPEC,
+              automaticLayout: true,
+              minimap: { enabled: false },
+              scrollBeyondLastLine: false,
+              fixedOverflowWidgets: true,
+              lineNumbersMinChars: 4,
+              showFoldingControls: 'always',
+              foldingHighlight: true,
+            }}
+            onChange={onCodeChange}
+            onMount={(editor: any) => {
+              monacoRef.current = editor;
+            }}
+          />
+        </div>
+      ))}
     </div>
   );
-}
+};

--- a/src/slots/CodeEditor/utils.ts
+++ b/src/slots/CodeEditor/utils.ts
@@ -46,7 +46,14 @@ export function extractImportDeps(sourceCode: string) {
   return deps;
 }
 
-export function getCodeSandboxConfig(title: string, sourceCode: string, fileExtension: string, deps: any, devDependencies: any, playground: any) {
+export function getCodeSandboxConfig(
+  title: string,
+  sourceCode: string,
+  fileExtension: string,
+  deps: any,
+  devDependencies: any,
+  playground: any,
+) {
   return {
     files: {
       'package.json': {
@@ -65,10 +72,17 @@ export function getCodeSandboxConfig(title: string, sourceCode: string, fileExte
     } as {
       [key: string]: any;
     },
-  }
+  };
 }
 
-export function getRiddleConfig(title: string, sourceCode: string, fileExtension: string, deps: any, devDependencies: any, playground: any) {
+export function getRiddleConfig(
+  title: string,
+  sourceCode: string,
+  fileExtension: string,
+  deps: any,
+  devDependencies: any,
+  playground: any,
+) {
   return {
     title,
     js: sourceCode,
@@ -82,7 +96,14 @@ export function getRiddleConfig(title: string, sourceCode: string, fileExtension
   };
 }
 
-export function getStackblitzConfig(title: string, sourceCode: string, fileExtension: string, deps: any, devDependencies: any, playground: any) {
+export function getStackblitzConfig(
+  title: string,
+  sourceCode: string,
+  fileExtension: string,
+  deps: any,
+  devDependencies: any,
+  playground: any,
+) {
   return {
     title: title || '',
     description: '',
@@ -95,7 +116,14 @@ export function getStackblitzConfig(title: string, sourceCode: string, fileExten
   };
 }
 
-export function getHtmlCodeTemplate(title: string, sourceCode: string, fileExtension: string, deps: any, devDependencies: any, playground: any) {
+export function getHtmlCodeTemplate(
+  title: string,
+  sourceCode: string,
+  fileExtension: string,
+  deps: any,
+  devDependencies: any,
+  playground: any,
+) {
   const { htmlCodeTemplate = '', container = '' } = playground;
   const insertCssMatcher = /insertCss\(`\s*(.*)\s*`\);/;
   const code = replaceFetchUrl(sourceCode)
@@ -109,30 +137,23 @@ export function getHtmlCodeTemplate(title: string, sourceCode: string, fileExten
   if (customStyles && customStyles[1]) {
     result = result.replace(
       '</head>',
-      `  <style>\n${indentString(
-        customStyles[1],
-        4,
-      )}\n    </style>\n  </head>`,
+      `  <style>\n${indentString(customStyles[1], 4)}\n    </style>\n  </head>`,
     );
   }
   if (container) {
-    result = result.replace(
-      '<body>',
-      `<body>\n${indentString(container, 4)}`,
-    );
+    result = result.replace('<body>', `<body>\n${indentString(container, 4)}`);
   }
   return result;
 }
 
-
 export function replaceInsertCss(str: string, lang: string) {
   const comment =
     lang === 'zh'
-    ? `// 我们用 insert-css 演示引入自定义样式
+      ? `// 我们用 insert-css 演示引入自定义样式
 // 推荐将样式添加到自己的样式文件中
 // 若拷贝官方代码，别忘了 npm install insert-css
 insertCss(`
-    : `// We use 'insert-css' to insert custom styles
+      : `// We use 'insert-css' to insert custom styles
 // It is recommended to add the style to your own style sheet files
 // If you want to copy the code directly, please remember to install the npm package 'insert-css
 insertCss(`;
@@ -148,7 +169,12 @@ insertCss(`;
  * @param replaceId rid
  * @param cb 回调错误
  */
-export function execute(code: string, playgroundScriptContainer: string, container: string, replaceId = 'container') {
+export function execute(
+  code: string,
+  playgroundScriptContainer: string,
+  container: string,
+  replaceId = 'container',
+) {
   const node = document.getElementById(playgroundScriptContainer);
   const script = document.createElement('script');
   // replace container id in case of multi demos in document
@@ -170,7 +196,8 @@ try {
 }
   `;
   // 追加图表容器
-  node.innerHTML = container || `<div id=${replaceId} class="playgroundCodeContainer" />`;
+  node.innerHTML =
+    container || `<div id=${replaceId} class="playgroundCodeContainer" />`;
   // 运行 script
   node!.appendChild(script);
 }
@@ -178,10 +205,15 @@ try {
 /**
  * 编译代码
  */
-export function compile(value: string, relativePath: string) {
+export function compile(value: string, relativePath: string, es5 = true) {
   const { code } = transform(value, {
     filename: relativePath,
-    presets: ['react', 'typescript', 'es2015', ['stage-3', { decoratorsBeforeExport: true }]],
+    presets: [
+      'react',
+      'typescript',
+      es5 ? 'es2015' : 'es2016',
+      ['stage-3', { decoratorsBeforeExport: true }],
+    ],
     plugins: ['transform-modules-umd'],
   });
   return code;


### PR DESCRIPTION
# Spec Tab

增加了 Spec Tab，并且修复了一系列问题：

![site-spec](https://user-images.githubusercontent.com/49330279/231389254-6de9d597-039b-4a96-8ef8-2c2b7bc3a38d.jpg)

## 实现思路

修改 G2 的 Chart 对象，在调用 render 方法的时候触发一个自定义事件抛出当前 options，editor 监听该事件并且更行 spec tab，**目前 spec tab 是只读的**。

## 使用方式

在 themeConfig 声明 `showSpecTab` 为 `true`，`es5` 为 `false`。

需要在 G2 的 .dumi/global.ts 定义如下的函数：

```js
// 对 G2 的 Chart 对象进行扩展
// 1. 可以自定义 spec 的展示内容和 key 的排序
// 2. 在 render 的时候触发 spec 事件抛出 spec，用于展示 spec
function extendG2(g2) {
  const { Chart: G2Chart, ...rest } = g2;

  // 这里只是对顶层 key 进行排序，在 G2 中还需要递归排序
  const sortKeys = (options) => {
    const newOptions = sortObject(options);
    return newOptions;
  };

  const sortObject = (
    obj,
    keys = [
      'type',
      'autoFit',
      'theme',
      'width',
      'height',
      'data',
      'encode',
      'transform',
      'scale',
      'coordinate',
      'axis',
      'legend',
      'label',
      'children',
    ].reverse(),
  ) => {
    const autoFit = Object.keys(obj).find((d) => d === 'autoFit');
    const filter = ([key, _]) =>
      !autoFit ? true : key === 'width' || key === 'height' ? false : true;
    return Object.fromEntries(
      Object.entries(obj)
        .sort(([a], [b]) => keys.indexOf(b) - keys.indexOf(a))
        .filter(filter),
    );
  };

  class Chart extends G2Chart {
    options() {
      if (arguments.length !== 0) return super.options(...arguments);
      const options = super.options();
      const { type, children = [], key, ...rest } = options;
      const topLevel =
        type === 'view' && children.length === 1
          ? { ...children[0], ...rest }
          : { type, children, ...rest };
      return sortKeys(topLevel);
    }
    render() {
      // 触发自定义事件
      const event = new CustomEvent('spec', {
        detail: {
          options: this.options(),
        },
      });
      window.dispatchEvent(event);
      return super.render();
    }
  }
  return { ...rest, Chart };
}
```

然后在挂载 G2 的地方对 Chart 对象进行增强:

```js
if (window) {
  (window as any).g2 = extendG2(require('@antv/g2/lib/index.js'));
}
```
## 修复问题

- 调用了 fetch 的案例有时不会有 data tab：匹配 fetch url 的正则没有考虑换行的情况。
- javascript tab 和 data tab 共享历史记录，撤销操作会互相影响：每一个 tab 对应一个独立的 editor 实例
- spec 里面有 fetch 的时候没有 data tab：配置 spec 里面的 fetch connector。



