### PR TITLE
feat: navs dropdownItems 下拉选项配置在 blank 的基础上支持本页面跳转

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,4 @@
 .DS_Store
 .idea
 pnpm-lock.yaml
+yarn.lock

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@antv/dumi-theme-antv",
-  "version": "0.3.12",
+  "version": "0.3.13",
   "description": "AntV website theme based on dumi2.",
   "types": "dist/types.d.ts",
   "scripts": {

--- a/src/slots/Header/Navs.tsx
+++ b/src/slots/Header/Navs.tsx
@@ -10,9 +10,10 @@ import styles from './index.module.less';
 type dropdownItem = {
   name: {
     [key: string]: string;
-  },
-  url: string
-}
+  };
+  url: string;
+  target?: '_blank';
+};
 
 export type INav = {
   slug?: string;
@@ -52,44 +53,52 @@ export const Navs: React.FC<NavProps> = ({ navs, path }) => {
           className = cx('header-menu-item-active', {
             [styles.activeItem]: getNavCategory(path) === getNavCategory(href)
           });
-       }
+        }
         return (
           size(nav.dropdownItems) ? 
             (
-              <li key={title} className={className}>
-                <Dropdown
-                  className={styles.ecoSystems}
-                  placement="bottom"
-                  overlay={
-                    <Menu>
-                      {nav.dropdownItems.map(({ name, url }) => (
-                        <Menu.Item key={url}>
-                          <a target="_blank" rel="noreferrer" href={url}>
-                            {name[locale.id]} <LinkOutlined />
+          <li key={title} className={className}>
+            <Dropdown
+              className={styles.ecoSystems}
+              placement="bottom"
+              overlay={
+                <Menu>
+                  {nav.dropdownItems.map(({ name, url, target }) => {
+                    const displayName = name[locale.id];
+                    return (
+                      <Menu.Item key={url}>
+                        {target === '_blank' || url.startsWith('http') ? (
+                          <a href={url} target="_blank" rel="noreferrer">
+                            {displayName}
+                            <LinkOutlined />
                           </a>
-                        </Menu.Item>
-                      ))}
-                    </Menu>
-                  }
-                >
-                  <span>
-                    {title}
-                    <DownOutlined />
-                  </span>
-                </Dropdown>
-            </li>
+                        ) : (
+                          <Link to={url}>{displayName}</Link>
+                        )}
+                      </Menu.Item>
+                    );
+                  })}
+                </Menu>
+              }
+            >
+              <span>
+                {title}
+                <DownOutlined />
+              </span>
+            </Dropdown>
+          </li>
             )
             :
            ( <li key={title} className={className}>
-              {nav.target === '_blank' || href.startsWith('http') ? (
+            {nav.target === '_blank' || href.startsWith('http') ? (
               <a href={href} target='_blank' rel='noreferrer'>
                 {title}
                 <LinkOutlined />
               </a>
-              ) : (
-               <Link to={href}>{title}</Link>
-             )}
-              </li>
+            ) : (
+              <Link to={href}>{title}</Link>
+            )}
+          </li>
             )
           )
       })}


### PR DESCRIPTION
当前 nav 下拉仅支持 `_blank` 新增 Tab 页跳转

```ts
<Menu>
   {nav.dropdownItems.map(({ name, url }) => (
        <Menu.Item key={url}>
           <a target="_blank" rel="noreferrer" href={url}>
              {name[locale.id]} <LinkOutlined />
           </a>
         </Menu.Item>
    ))}
</Menu>
```

新增支持对跳转方式进行控制，仅对配置 target 为 `_blank` 或者 url 为超链接格式的地址按照新增 Tab 页的方式跳转，其余默认保持在当前页面跳转。

```ts
<Menu>
  {nav.dropdownItems.map(({ name, url, target }) => {
   const displayName = name[locale.id];
   return (
    <Menu.Item key={url}>
      {target === '_blank' || url.startsWith('http') ? (
         <a href={url} target="_blank" rel="noreferrer">
          {displayName}
           <LinkOutlined />
          </a>
       ) : (
           <Link to={url}>{displayName}</Link>
      )}
     </Menu.Item> 
    );
  })}
</Menu>
```