### PR TITLE
fix: cases buttons center

### DIFF
--- a/src/slots/Cases/index.module.less
+++ b/src/slots/Cases/index.module.less
@@ -75,6 +75,9 @@
           line-height: 47px;
           border: 1px solid #a3b1bf;
           transition: all 0.3s;
+          display: flex;
+          justify-content: center;
+          align-items: center;
 
           &:hover {
             border: 1px solid #ced4d9;
@@ -86,7 +89,6 @@
           }
 
           .controlButtonIcon {
-            width: 100%;
             color: #a3b1bf;
             transition: all 0.3s;
           }


### PR DESCRIPTION
![image](https://github.com/antvis/dumi-theme-antv/assets/65594180/9004f00d-c15c-4ea2-82c7-178095a000fa)
