### PR TITLE
feat: add preview function for example page api

### DIFF
--- a/example/.dumirc.ts
+++ b/example/.dumirc.ts
@@ -2,34 +2,41 @@ import { defineConfig } from 'dumi';
 import { repository, version } from './package.json';
 
 export default defineConfig({
-  locales: [{ id: 'zh', name: '中文' }, { id: 'en', name: 'English' }],
-  title: 'dumi-theme-antv 主题包',                                        // 网站header标题
-  favicons: ['https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*7svFR6wkPMoAAAAAAAAAAAAADmJ7AQ/original'], // 网站 favicon
-  metas: [                                                              // 自定义 meta 标签  
+  locales: [
+    { id: 'zh', name: '中文' },
+    { id: 'en', name: 'English' },
+  ],
+  title: 'dumi-theme-antv 主题包', // 网站header标题
+  favicons: [
+    'https://mdn.alipayobjects.com/huamei_qa8qxu/afts/img/A*7svFR6wkPMoAAAAAAAAAAAAADmJ7AQ/original',
+  ], // 网站 favicon
+  metas: [
+    // 自定义 meta 标签
     { name: 'keywords', content: 'dumi-theme-antv' },
     { name: 'description', content: '基于 dumi2 的 AntV 官网主题包' },
   ],
   themeConfig: {
     title: 'dumi-theme-antv',
     description: '基于 dumi2 的 AntV 官网主题包',
-    defaultLanguage: 'zh',                                              // 默认语言
-    isAntVSite: false,                                                  // 是否是 AntV 的大官网
+    defaultLanguage: 'zh', // 默认语言
+    isAntVSite: false, // 是否是 AntV 的大官网
     footerTheme: 'light',
-    siteUrl: 'https://antv.vision',                                     // 官网地址
-    githubUrl: repository.url,                                          // GitHub 地址
-    showSearch: true,                                                   // 是否显示搜索框
-    showGithubCorner: true,                                             // 是否显示头部的 GitHub icon
-    showGithubStars: true,                                              // 是否显示 GitHub star 数量
-    showAntVProductsCard: true,                                         // 是否显示 AntV 产品汇总的卡片
-    showLanguageSwitcher: true,                                         // 是否显示官网语言切换
-    showWxQrcode: true,                                                 // 是否显示头部菜单的微信公众号
-    showChartResize: true,                                              // 是否在 demo 页展示图表视图切换
+    siteUrl: 'https://antv.vision', // 官网地址
+    githubUrl: repository.url, // GitHub 地址
+    showSearch: true, // 是否显示搜索框
+    showGithubCorner: true, // 是否显示头部的 GitHub icon
+    showGithubStars: true, // 是否显示 GitHub star 数量
+    showAntVProductsCard: true, // 是否显示 AntV 产品汇总的卡片
+    showLanguageSwitcher: true, // 是否显示官网语言切换
+    showWxQrcode: true, // 是否显示头部菜单的微信公众号
+    showChartResize: true, // 是否在 demo 页展示图表视图切换
     showAPIDoc: true,
-    showSpecTab: true,                                                // 是否在 demo 页展示API文档
+    showSpecTab: true, // 是否在 demo 页展示API文档
     themeSwitcher: 'g2',
     es5: false,
     version,
-    versions: {                                                         // 历史版本以及切换下拉菜单
+    versions: {
+      // 历史版本以及切换下拉菜单
       '0.3.x': 'https://g.antv.vision/',
       '0.2.x': 'https://g2.antv.vision/',
     },
@@ -40,7 +47,8 @@ export default defineConfig({
         en: 'China Mirror',
       },
     },
-    docsearchOptions: {                                                 // 头部搜索框配置
+    docsearchOptions: {
+      // 头部搜索框配置
       versionV3: true,
       apiKey: '90c9a5dbf6e5ea7058cc32bcde8e94b2',
       indexName: 's2-antv-vision',
@@ -49,7 +57,8 @@ export default defineConfig({
     /**
      *  tips: 文档列表类型的路由导航(nav) 请以 docs/* 格式命名
      */
-    navs: [                                                             // 头部的菜单列表
+    navs: [
+      // 头部的菜单列表
       {
         slug: 'docs/manual/concepts/grammar-of-graphics',
         title: {
@@ -83,15 +92,16 @@ export default defineConfig({
           {
             name: {
               zh: 'Dumi 2.x',
-              en: 'Dumi 2.x'
+              en: 'Dumi 2.x',
             },
             url: 'https://github.com/umijs/dumi',
-          }
+          },
         ],
         order: 0,
       },
     ],
-    ecosystems: [                                                       // 头部的菜单中的「周边生态」
+    ecosystems: [
+      // 头部的菜单中的「周边生态」
       {
         name: {
           zh: 'G2 官网',
@@ -105,7 +115,7 @@ export default defineConfig({
           en: 'G6 website',
         },
         url: 'https://g6.antv.vision',
-      }
+      },
     ],
     docs: [
       {
@@ -159,7 +169,7 @@ export default defineConfig({
           en: 'Show Case',
         },
         icon: 'gallery',
-      }
+      },
     ],
     playground: {
       devDependencies: {
@@ -200,7 +210,8 @@ export default defineConfig({
         zh: '基于 dumi2 封装，提供灵活多变的 slots 插槽，抽取大量配置，一秒搭建 AntV 的各个技术栈官网。',
         en: 'Based on the dumi2 package, it provides flexible and changeable slots, extracts a large number of configurations, and builds the official website of each technology stack of AntV in one second.',
       },
-      image: 'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*wo_LToatmbwAAAAAAAAAAABkARQnAQ',
+      image:
+        'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*wo_LToatmbwAAAAAAAAAAABkARQnAQ',
       buttons: [
         {
           text: {
@@ -250,7 +261,7 @@ export default defineConfig({
     features: {
       title: {
         zh: '我们的优势',
-        en: 'Our advantage'
+        en: 'Our advantage',
       },
       cards: [
         {
@@ -284,9 +295,9 @@ export default defineConfig({
           description: {
             zh: '强大的交互语法，助力可视分析，让图表栩栩如生',
             en: 'owerful interactive syntax to help visual analysis and make charts come alive',
-          }
+          },
         },
-      ]
+      ],
     },
     /** 首页案例 */
     cases: [
@@ -298,43 +309,70 @@ export default defineConfig({
         },
         description: {
           zh: '真实的数据可视化案例，我们将它们归纳为一个个故事性的设计模板，让用户达到开箱即用的效果。',
-          en: 'Real data visualization cases, we summarize them into story-based design templates, allowing users to achieve out-of-the-box effects.'
+          en: 'Real data visualization cases, we summarize them into story-based design templates, allowing users to achieve out-of-the-box effects.',
         },
         // link: `/examples/gallery`,
-        image: 'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*hDrgRb7ma4EAAAAAAAAAAABkARQnAQ'
+        image:
+          'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*hDrgRb7ma4EAAAAAAAAAAABkARQnAQ',
       },
     ],
     /** 首页合作公司 */
     companies: [
-      { name: '阿里云', img: 'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*V_xMRIvw2iwAAAAAAAAAAABkARQnAQ' },
-      { name: '支付宝', img: 'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*lYDrRZvcvD4AAAAAAAAAAABkARQnAQ', },
-      { name: '天猫', img: 'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*BQrxRK6oemMAAAAAAAAAAABkARQnAQ', },
-      { name: '淘宝网', img: 'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*1l8-TqUr7UcAAAAAAAAAAABkARQnAQ', },
-      { name: '网上银行', img: 'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*ZAKFQJ5Bz4MAAAAAAAAAAABkARQnAQ', },
-      { name: '京东', img: 'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*yh-HRr3hCpgAAAAAAAAAAABkARQnAQ', },
-      { name: 'yunos', img: 'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*_js7SaNosUwAAAAAAAAAAABkARQnAQ', },
-      { name: '菜鸟', img: 'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*TgV-RZDODJIAAAAAAAAAAABkARQnAQ', },
+      {
+        name: '阿里云',
+        img: 'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*V_xMRIvw2iwAAAAAAAAAAABkARQnAQ',
+      },
+      {
+        name: '支付宝',
+        img: 'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*lYDrRZvcvD4AAAAAAAAAAABkARQnAQ',
+      },
+      {
+        name: '天猫',
+        img: 'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*BQrxRK6oemMAAAAAAAAAAABkARQnAQ',
+      },
+      {
+        name: '淘宝网',
+        img: 'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*1l8-TqUr7UcAAAAAAAAAAABkARQnAQ',
+      },
+      {
+        name: '网上银行',
+        img: 'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*ZAKFQJ5Bz4MAAAAAAAAAAABkARQnAQ',
+      },
+      {
+        name: '京东',
+        img: 'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*yh-HRr3hCpgAAAAAAAAAAABkARQnAQ',
+      },
+      {
+        name: 'yunos',
+        img: 'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*_js7SaNosUwAAAAAAAAAAABkARQnAQ',
+      },
+      {
+        name: '菜鸟',
+        img: 'https://gw.alipayobjects.com/mdn/rms_2274c3/afts/img/A*TgV-RZDODJIAAAAAAAAAAABkARQnAQ',
+      },
     ],
     // 代码编辑器设置
     editor: {
-      size: 0.4,   // 代码区占比
+      size: 0.4, // 代码区占比
       playgroundSize: 0.38, // 文档中的代码区占比
-    }
+    },
   },
   analytics: {
     // google analytics 的 key (GA 4)
     // ga_v2: 'G-abcdefg',
     // 若你在使用 GA v1 旧版本，请使用 `ga` 来配置
-    ga: 'ga_old_key'
+    ga: 'ga_old_key',
     // 百度统计的 key
     // baidu: 'baidu_tongji_key',
   },
   // tnpm 安装的目录会导致 webpack 缓存快照 OOM，暂时禁用
   // 只有主题包开发需要用，其他技术栈使用的时候，不需要！
-  chainWebpack(memo) { memo.delete('cache'); return memo },
+  chainWebpack(memo) {
+    memo.delete('cache');
+    return memo;
+  },
   plugins: [],
-  links: [
-  ],
-  scripts: [
-  ],
+  links: [],
+  scripts: [],
+  mfsu: false,
 });

--- a/example/docs/plots/bar.en.md
+++ b/example/docs/plots/bar.en.md
@@ -1,0 +1,6 @@
+---
+title: Bar
+order: 7
+---
+
+API

--- a/example/docs/plots/bar.zh.md
+++ b/example/docs/plots/bar.zh.md
@@ -1,0 +1,10 @@
+---
+title: 条形图
+order: 7
+---
+
+## 背景
+
+数据映射到图形时必须进行视觉编码，视觉编码包括几何标记和视觉通道，几何标记对应着多种图表类型，视觉通道定义图形属性。视觉通道中最具区分度的通道是位置（position)，图形的位置在一些情况下会出现重叠：
+
+![image.png](https://gw.alipayobjects.com/mdn/rms_f5c722/afts/img/A*Tx_pTrx1WB8AAAAAAAAAAABkARQnAQ)

--- a/example/examples/case/bar/API.en.md
+++ b/example/examples/case/bar/API.en.md
@@ -1,1 +1,1 @@
-`markdown:docs/common/api.en.md`
+`markdown:docs/plots/bar.en.md`

--- a/example/examples/case/bar/API.zh.md
+++ b/example/examples/case/bar/API.zh.md
@@ -1,1 +1,1 @@
-`markdown:docs/common/api.zh.md`
+`markdown:docs/plots/bar.zh.md`

--- a/example/package.json
+++ b/example/package.json
@@ -7,7 +7,7 @@
     "preview": "dumi preview"
   },
   "dependencies": {
-    "@antv/g2": "^5.0.0-alpha.3",
+    "@antv/g2": "^5.0.0",
     "d3-regression": "^1.3.10"
   },
   "repository": {

--- a/package.json
+++ b/package.json
@@ -71,8 +71,10 @@
     "indent-string": "^5.0.0",
     "insert-css": "^2.0.0",
     "lodash-es": "^4.17.21",
+    "markdown-to-jsx": "^7.3.2",
     "monaco-editor": "^0.25.0",
     "parse-github-url": "^1.0.2",
+    "prettier": "^2.7.1",
     "rc-drawer": "^4.0.0",
     "rc-footer": "^0.6.6",
     "react": "^18.2.0",
@@ -91,8 +93,8 @@
     "unified": "^10.1.2",
     "unist-util-visit": "^4.1.2",
     "uri-parse": "^1.0.0",
-    "video-react": "^0.16.0",
-    "prettier": "^2.7.1"
+    "valtio": "^1.12.1",
+    "video-react": "^0.16.0"
   },
   "peerDependencies": {
     "dumi": "^2.0.0",

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -1,0 +1,11 @@
+import { proxy } from 'valtio';
+
+export const store = proxy<{
+  hideMenu: boolean;
+  showAPI: boolean;
+  apiContainerWidth: number;
+}>({
+  hideMenu: false,
+  showAPI: false,
+  apiContainerWidth: 300,
+});

--- a/src/pages/Example/components/CollapsedIcon/index.module.less
+++ b/src/pages/Example/components/CollapsedIcon/index.module.less
@@ -1,0 +1,14 @@
+@collapsed-icon-size: 36px;
+
+.collapsed {
+  position: absolute;
+  z-index: 3;
+  width: 24px;
+  height: @collapsed-icon-size;
+  line-height: @collapsed-icon-size;
+  font-size: 18px;
+  color: #777;
+  cursor: pointer;
+  background: #f8f9fc;
+  text-align: center;
+}

--- a/src/pages/Example/components/CollapsedIcon/index.tsx
+++ b/src/pages/Example/components/CollapsedIcon/index.tsx
@@ -1,0 +1,23 @@
+import { DoubleLeftOutlined, DoubleRightOutlined } from '@ant-design/icons';
+import React from 'react';
+import styles from './index.module.less';
+
+interface CollapsedProps {
+  isCollapsed: boolean;
+  style?: React.CSSProperties;
+  onClick?: (isCollapsed: boolean) => void;
+}
+export const CollapsedIcon: React.FC<CollapsedProps> = (props) => {
+  const { isCollapsed, onClick, style } = props;
+  return (
+    <div
+      className={styles.collapsed}
+      onClick={() => {
+        onClick(!isCollapsed);
+      }}
+      style={style}
+    >
+      {isCollapsed ? <DoubleRightOutlined /> : <DoubleLeftOutlined />}
+    </div>
+  );
+};

--- a/src/pages/Example/index.tsx
+++ b/src/pages/Example/index.tsx
@@ -1,15 +1,19 @@
 import { Layout } from 'antd';
 import { useLocale, useSiteData } from 'dumi';
-import { get, find } from 'lodash-es';
-import React, { useContext, useEffect, useState, useMemo } from 'react';
+import { every, find, get } from 'lodash-es';
+import React, { useContext, useEffect, useMemo, useState } from 'react';
 import { useLocation, useNavigate, useParams } from 'react-router-dom';
+import { useSnapshot } from 'valtio';
 import { ThemeAntVContext } from '../../context';
+import { store } from '../../model';
+import { API } from '../../slots/API';
 import { CodeRunner } from '../../slots/CodeRunner';
 import { getDemoInfo } from '../../slots/CodeRunner/utils';
 import { ExampleSider } from '../../slots/ExampleSider';
 import { Header } from '../../slots/Header';
 import { SEO } from '../../slots/SEO';
 import { Demo, ExampleTopic } from '../../types';
+import { CollapsedIcon } from './components/CollapsedIcon';
 import styles from './index.module.less';
 import { getCurrentTitle } from './utils';
 
@@ -55,8 +59,7 @@ const Example: React.FC = () => {
   }, [hash, exampleTopics, example]);
 
   const [currentDemo, setCurrentDemo] = useState<Demo>();
-
-  const [isCollapsed, setIsCollapsed] = useState<boolean>(false);
+  const state = useSnapshot(store);
 
   const [title, setTitle] = useState<title>({});
 
@@ -67,6 +70,12 @@ const Example: React.FC = () => {
       setTitle(getCurrentTitle(exampleTopics, topic, example));
     }
   }, [topic, example, hash]);
+
+  const showAPI = every(
+    [get(themeConfig, 'showAPIDoc'), topic, example],
+    Boolean,
+  );
+
   return (
     <div className={styles.example}>
       <SEO title={title[locale.id]} lang={locale.id} />
@@ -77,7 +86,7 @@ const Example: React.FC = () => {
           width={250}
           trigger={null}
           collapsible
-          collapsed={isCollapsed}
+          collapsed={state.hideMenu}
           className={styles.menuSider}
           theme="light"
         >
@@ -94,6 +103,13 @@ const Example: React.FC = () => {
               exampleTopics={exampleTopics}
             />
           )}
+          <CollapsedIcon
+            isCollapsed={state.hideMenu}
+            onClick={(show) => {
+              store.hideMenu = show;
+            }}
+            style={{ bottom: 0, right: state.hideMenu ? -24 : 0 }}
+          />
         </Sider>
         {/*//FIXME: 待 ANTD bug 修复后，可以使用下面的代码*/}
         {/*<LeftOutlined
@@ -116,6 +132,15 @@ const Example: React.FC = () => {
             />
           )}
         </Content>
+        {showAPI && (
+          <API
+            exampleTopics={exampleTopics}
+            topic={topic}
+            example={example}
+            demo={demo}
+            language={locale.id}
+          />
+        )}
       </Layout>
     </div>
   );

--- a/src/plugin/api.ts
+++ b/src/plugin/api.ts
@@ -1,0 +1,37 @@
+import * as fs from 'fs-extra';
+
+const MARKDOW_REG_NSIGN = /`markdown:(\S+)`/g;
+
+const getContent = (filePath: string) => {
+  let content: string = '';
+  try {
+    const currentContent = fs.readFileSync(filePath).toString();
+    const lines = currentContent.split('\n');
+    lines.forEach((line, index) => {
+      if (line.match(MARKDOW_REG_NSIGN)) {
+        let nestedPath = '';
+        line.replace(MARKDOW_REG_NSIGN, (match, p1) => {
+          nestedPath = p1;
+          return '';
+        });
+        content += getContent(nestedPath);
+      } else {
+        content += `${line} \n`;
+      }
+    });
+  } catch (e) {
+    console.error(e);
+  } finally {
+    return content;
+  }
+};
+
+/**
+ * 获取API
+ *
+ * @param {string} apiPath API路径
+ * @returns {string} 文件内容
+ */
+export const getExampleAPI = (apiPath: string) => {
+  return getContent(apiPath);
+};

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -91,6 +91,7 @@ export default function ThemeAntVContextWrapper() {
         meta: ${JSON.stringify({
           exampleTopics: getExamplesPageTopics(
             api.config.themeConfig.examples || [],
+            api.userConfig.themeConfig.showAPIDoc,
           ),
         })}
       }}

--- a/src/slots/API/index.module.less
+++ b/src/slots/API/index.module.less
@@ -1,0 +1,39 @@
+.api {
+  height: 100%;
+
+  .header {
+    position: relative;
+    height: 36px;
+    background-color: #f8f9fc;
+    display: flex;
+    justify-content: end;
+    overflow: hidden;
+    padding-right: 12px;
+
+    .zoom {
+      font-size: 18px;
+      color: #777;
+      line-height: 36px;
+    }
+  }
+
+  .content {
+    overflow: hidden;
+    padding: 12px;
+    border-left: 1px solid #ececec;
+    height: calc(100% - 36px);
+    overflow-y: scroll;
+
+    > div {
+      overflow: hidden;
+
+      > p:first-child {
+        display: none;
+      }
+    }
+  }
+
+  img {
+    max-width: 100%;
+  }
+}

--- a/src/slots/API/index.tsx
+++ b/src/slots/API/index.tsx
@@ -1,0 +1,85 @@
+import { ZoomInOutlined, ZoomOutOutlined } from '@ant-design/icons';
+import { Popover } from 'antd';
+import { get } from 'lodash-es';
+import Markdown from 'markdown-to-jsx';
+import React from 'react';
+import { useSnapshot } from 'valtio';
+import { store } from '../../model';
+import { CollapsedIcon } from '../../pages/Example/components/CollapsedIcon';
+import { ExampleTopic } from '../../types';
+import { getDemoInfo } from '../CodeRunner/utils';
+import styles from './index.module.less';
+
+type APIProps = {
+  isPlayground?: boolean;
+  topic: string;
+  example: string;
+  demo: string;
+  exampleTopics: ExampleTopic[];
+  language?: string;
+};
+const EMPTY = /^\s*$/;
+/**
+ * API 预览
+ */
+export const API = ({
+  exampleTopics,
+  topic,
+  example,
+  demo,
+  language = 'zh',
+}: APIProps) => {
+  const state = useSnapshot(store);
+  const demoInfo = getDemoInfo(exampleTopics, topic, example, demo);
+  const APIContent = get(demoInfo, ['api', language]);
+
+  return (
+    <div
+      className={styles.api}
+      style={{ width: state.showAPI ? state.apiContainerWidth : 24 }}
+    >
+      <div className={styles.header}>
+        <div className={styles.zoom}>
+          <ZoomInOutlined
+            onClick={() => {
+              store.apiContainerWidth += 100;
+            }}
+          />
+          <ZoomOutOutlined
+            style={{ marginLeft: 8 }}
+            onClick={() => {
+              if (state.apiContainerWidth > 150) {
+                store.apiContainerWidth -= 100;
+              }
+            }}
+          />
+        </div>
+        <Popover
+          content={language === 'zh' ? '展示文档' : 'Show docs'}
+          placement="right"
+        >
+          <CollapsedIcon
+            isCollapsed={state.showAPI}
+            onClick={(show: boolean) => {
+              store.showAPI = show;
+            }}
+            style={{
+              left: 0,
+              top: 0,
+            }}
+          />
+        </Popover>
+      </div>
+      <div className={styles.content}>
+        {!EMPTY.test(APIContent) ? (
+          <Markdown>{APIContent}</Markdown>
+        ) : (
+          <div style={{ textAlign: 'center' }}>
+            <h1>404</h1>
+            <p>Sorry, the API you visited does not exist.</p>
+          </div>
+        )}
+      </div>
+    </div>
+  );
+};

--- a/src/slots/CodeRunner/utils.ts
+++ b/src/slots/CodeRunner/utils.ts
@@ -9,7 +9,7 @@ import { Demo, ExampleTopic } from '../../types';
 export function getExampleTopicMap(exampleTopics: ExampleTopic[]) {
   const exampleTopicMap = new Map<string, Demo>();
 
-  map(exampleTopics, ((topic) => {
+  map(exampleTopics, (topic) => {
     map(topic.examples, (example) => {
       map(example.demos, (demo) => {
         exampleTopicMap.set(`${topic.id}-${example.id}-${demo.id}`, {
@@ -17,10 +17,11 @@ export function getExampleTopicMap(exampleTopics: ExampleTopic[]) {
           relativePath: `${topic.id}/${example.id}/demo/${demo.filename}`,
           targetExample: example,
           targetTopic: topic,
+          api: example.api,
         });
       });
     });
-  }));
+  });
 
   return exampleTopicMap;
 }
@@ -28,7 +29,12 @@ export function getExampleTopicMap(exampleTopics: ExampleTopic[]) {
 /**
  * 从 Context 信息中，获取到 Example 相关的信息，用于页面渲染
  */
-export function getDemoInfo(exampleTopics: ExampleTopic[], topic: string, example: string, demo: string) {
+export function getDemoInfo(
+  exampleTopics: ExampleTopic[],
+  topic: string,
+  example: string,
+  demo: string,
+) {
   const m = getExampleTopicMap(exampleTopics);
 
   return m.get(`${topic}-${example}-${demo}`);


### PR DESCRIPTION
1. 新增示例页面导航折叠功能
2. 新增示例页面 API 预览功能（默认收起，可通过ShowAPIDoc控制是否展示）

![image](https://github.com/antvis/dumi-theme-antv/assets/31396322/1f425d6a-e0ea-4e29-8995-3d0a20647931)
