### PR TITLE
feat: api collapsed

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+public-hoist-pattern[]=*

--- a/package.json
+++ b/package.json
@@ -89,6 +89,7 @@
     "react-use": "^17.4.0",
     "reading-time": "^1.5.0",
     "rehype-raw": "^7.0.0",
+    "remark-gfm": "^4.0.0",
     "semver": "^7.3.8",
     "size-sensor": "^1.0.1",
     "slick-carousel": "^1.8.1",

--- a/package.json
+++ b/package.json
@@ -1,31 +1,35 @@
 {
   "name": "@antv/dumi-theme-antv",
-  "version": "0.4.6",
+  "version": "0.5.0",
   "description": "AntV website theme based on dumi2.",
-  "types": "dist/types.d.ts",
-  "scripts": {
-    "start": "cd example && npm run start",
-    "dev": "father dev",
-    "build": "npm run prepare && father build",
-    "prepare": "father link-dev-theme",
-    "lint": "npm run lint:es && npm run lint:css",
-    "lint:css": "stylelint \"{src,test}/**/*.{css,less}\"",
-    "lint:es": "eslint \"{src,test}/**/*.{js,jsx,ts,tsx}\"",
-    "prepublishOnly": "npm run build"
-  },
   "keywords": [
     "dumi",
     "dumi-theme",
     "dumi-theme-antv"
   ],
-  "authors": [
-    "dumi",
-    "antv"
-  ],
+  "homepage": "https://github.com/antvis/dumi-theme-antv#readme",
+  "bugs": {
+    "url": "https://github.com/antvis/dumi-theme-antv/issues"
+  },
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/antvis/dumi-theme-antv"
+  },
   "license": "MIT",
+  "types": "dist/types.d.ts",
   "files": [
     "dist"
   ],
+  "scripts": {
+    "build": "npm run prepare && father build",
+    "dev": "father dev",
+    "lint": "npm run lint:es && npm run lint:css",
+    "lint:css": "stylelint \"{src,test}/**/*.{css,less}\"",
+    "lint:es": "eslint \"{src,test}/**/*.{js,jsx,ts,tsx}\"",
+    "prepare": "father link-dev-theme",
+    "prepublishOnly": "npm run build",
+    "start": "cd example && npm run start"
+  },
   "commitlint": {
     "extends": [
       "@commitlint/config-conventional"
@@ -48,9 +52,6 @@
       "prettier --parser=typescript --write"
     ]
   },
-  "publishConfig": {
-    "access": "public"
-  },
   "dependencies": {
     "@ant-design/icons": "^4.7.0",
     "@babel/plugin-syntax-unicode-sets-regex": "^7.18.6",
@@ -71,7 +72,6 @@
     "indent-string": "^5.0.0",
     "insert-css": "^2.0.0",
     "lodash-es": "^4.17.21",
-    "markdown-to-jsx": "^7.3.2",
     "monaco-editor": "^0.25.0",
     "parse-github-url": "^1.0.2",
     "prettier": "^2.7.1",
@@ -82,11 +82,13 @@
     "react-error-boundary": "^3.1.4",
     "react-github-button": "^0.1.11",
     "react-helmet": "^6.1.0",
+    "react-markdown": "^9.0.1",
     "react-router-dom": "^6.4.2",
     "react-slick": "^0.29.0",
     "react-split-pane": "^0.1.92",
     "react-use": "^17.4.0",
     "reading-time": "^1.5.0",
+    "rehype-raw": "^7.0.0",
     "semver": "^7.3.8",
     "size-sensor": "^1.0.1",
     "slick-carousel": "^1.8.1",
@@ -95,11 +97,6 @@
     "uri-parse": "^1.0.0",
     "valtio": "^1.12.1",
     "video-react": "^0.16.0"
-  },
-  "peerDependencies": {
-    "dumi": "^2.0.0",
-    "react": ">=16.9.0",
-    "react-dom": ">=16.9.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.1.2",
@@ -125,12 +122,16 @@
     "react-dom": "^18.0.0",
     "stylelint": "^14.9.1"
   },
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/antvis/dumi-theme-antv"
+  "peerDependencies": {
+    "dumi": "^2.0.0",
+    "react": ">=16.9.0",
+    "react-dom": ">=16.9.0"
   },
-  "bugs": {
-    "url": "https://github.com/antvis/dumi-theme-antv/issues"
+  "publishConfig": {
+    "access": "public"
   },
-  "homepage": "https://github.com/antvis/dumi-theme-antv#readme"
+  "authors": [
+    "dumi",
+    "antv"
+  ]
 }

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -7,5 +7,5 @@ export const store = proxy<{
 }>({
   hideMenu: false,
   showAPI: false,
-  apiContainerWidth: 300,
+  apiContainerWidth: 360,
 });

--- a/src/model/index.ts
+++ b/src/model/index.ts
@@ -7,5 +7,5 @@ export const store = proxy<{
 }>({
   hideMenu: false,
   showAPI: false,
-  apiContainerWidth: 360,
+  apiContainerWidth: 420,
 });

--- a/src/plugin/api.ts
+++ b/src/plugin/api.ts
@@ -1,29 +1,56 @@
 import * as fs from 'fs-extra';
 
-const MARKDOW_REG_NSIGN = /`markdown:(\S+)`/g;
+const MARKDOWN_REG_SIGN = /`markdown:([^`]*)`/g;
+const EMBED_REG_SIGN = /<embed[^>]*src=["']([^"']*)["'][^>]*[>\/>]/g;
 
 const getContent = (filePath: string) => {
   let content: string = '';
   try {
     const currentContent = fs.readFileSync(filePath).toString();
     const lines = currentContent.split('\n');
+    let isTitle = false;
     lines.forEach((line, index) => {
-      if (line.match(MARKDOW_REG_NSIGN)) {
-        let nestedPath = '';
-        line.replace(MARKDOW_REG_NSIGN, (match, p1) => {
-          nestedPath = p1;
-          return '';
-        });
-        content += getContent(nestedPath);
+      /**
+       * @description 示例页面无需 title 信息，冗余
+       * @example
+       *  ---
+       *  title: 条形图
+       *  order: 7
+       *  ---
+       */
+      if (line.startsWith('---')) {
+        isTitle = !isTitle;
       } else {
-        content += `${line} \n`;
+        if (!isTitle) {
+          let nestedPath = '';
+          const markdownMatch = MARKDOWN_REG_SIGN.exec(line);
+          const embedMatch = EMBED_REG_SIGN.exec(line);
+          /**
+           * @description 如果是 markdown 语法，则读取 markdown 文件内容
+           * @example `markdown:docs/plots/bar.zh.md`
+           */
+          if (markdownMatch) {
+            nestedPath = markdownMatch[1];
+          }
+          /**
+           * @description 如果是 embed 语法，则读取 embed 文件内容
+           * @example `<embed src="@/docs/options/plots/overview.zh.md"></embed>`
+           */
+          if (embedMatch) {
+            nestedPath = embedMatch[1].replace(/@\//g, '');
+          }
+          if (nestedPath) {
+            content += getContent(nestedPath);
+          } else {
+            content += `${line} \n`;
+          }
+        }
       }
     });
   } catch (e) {
     console.error(e);
-  } finally {
-    return content;
   }
+  return content;
 };
 
 /**
@@ -32,6 +59,10 @@ const getContent = (filePath: string) => {
  * @param {string} apiPath API路径
  * @returns {string} 文件内容
  */
-export const getExampleAPI = (apiPath: string) => {
+export const getExampleAPI = (apiPath: string): string => {
+  if (!fs.existsSync(apiPath)) {
+    console.error(`File does not exist: ${apiPath}`);
+    return '';
+  }
   return getContent(apiPath);
 };

--- a/src/plugin/api.ts
+++ b/src/plugin/api.ts
@@ -1,7 +1,7 @@
 import * as fs from 'fs-extra';
 
-const MARKDOWN_REG_SIGN = /`markdown:([^`]*)`/g;
-const EMBED_REG_SIGN = /<embed[^>]*src=["']([^"']*)["'][^>]*[>\/>]/g;
+const MARKDOWN_REG_SIGN = /`markdown:([^`]*)`/;
+const EMBED_REG_SIGN = /<embed[^>]*src=["']([^"']*)["'][^>]*[>/>]/;
 
 const getContent = (filePath: string) => {
   let content: string = '';
@@ -9,7 +9,7 @@ const getContent = (filePath: string) => {
     const currentContent = fs.readFileSync(filePath).toString();
     const lines = currentContent.split('\n');
     let isTitle = false;
-    lines.forEach((line, index) => {
+    lines.forEach((line) => {
       /**
        * @description 示例页面无需 title 信息，冗余
        * @example

--- a/src/slots/API/index.module.less
+++ b/src/slots/API/index.module.less
@@ -23,7 +23,7 @@
     .disorganized {
       padding: 0 12px;
 
-      &:first-child {
+      > :first-child {
         margin-top: 12px;
       }
     }

--- a/src/slots/API/index.module.less
+++ b/src/slots/API/index.module.less
@@ -45,6 +45,27 @@
        margin-top: 0;
      }
     }
+
+    .border() {
+      border-width: 1px;
+      border-color: #ececec
+    }
+
+    table {
+      .border();
+
+      border-right-style: solid;
+      border-top-style: solid;
+    }
+
+    td, th {
+      .border();
+
+      text-align: left;
+      border-left-style: solid;
+      border-bottom-style: solid;
+      padding: 4px;
+    }
   }
 
   img {

--- a/src/slots/API/index.module.less
+++ b/src/slots/API/index.module.less
@@ -1,5 +1,6 @@
 .api {
   height: 100%;
+  color: rgba(0,0,0, 85%);
 
   .header {
     position: relative;
@@ -33,16 +34,19 @@
     }
 
     p {
-      margin-bottom: 4px;
+      margin-bottom: 0;
     }
 
     h1, h2, h3, h4, h5, h6 {
-     font-weight: bold;
+     font-weight: 400;
      margin-bottom: 0;
-     margin-top: 12px;
+     margin-top: 8px;
+     color: rgba(0,0,0, 85%);
+     border-top: 1px solid #F8F9FC;
 
      &:first-child {
        margin-top: 0;
+       border-top: none;
      }
     }
 
@@ -56,6 +60,7 @@
 
       border-right-style: solid;
       border-top-style: solid;
+      margin-bottom: 6px;
     }
 
     td, th {
@@ -74,13 +79,15 @@
 
   :global {
     .ant-collapse-ghost > .ant-collapse-item > .ant-collapse-content > .ant-collapse-content-box {
-      padding-top: 0;
-      padding-bottom: 0;
-      padding-left: 24px;
+      padding: 0 4px 0 24px;
     }
 
     .ant-collapse > .ant-collapse-item > .ant-collapse-header {
-      padding: 12px;
+      padding: 8px;
+
+      .ant-collapse-arrow {
+        margin-right: 6px;
+      }
     }
   }
 }

--- a/src/slots/API/index.module.less
+++ b/src/slots/API/index.module.less
@@ -6,34 +6,60 @@
     height: 36px;
     background-color: #f8f9fc;
     display: flex;
-    justify-content: end;
+    justify-content: space-between;
     overflow: hidden;
     padding-right: 12px;
-
-    .zoom {
-      font-size: 18px;
-      color: #777;
-      line-height: 36px;
-    }
+    padding-left: 36px;
+    color: #777;
+    line-height: 36px;
   }
 
   .content {
     overflow: hidden;
-    padding: 12px;
     border-left: 1px solid #ececec;
     height: calc(100% - 36px);
     overflow-y: scroll;
 
-    > div {
-      overflow: hidden;
+    .disorganized {
+      padding: 0 12px;
 
-      > p:first-child {
-        display: none;
+      &:first-child {
+        margin-top: 12px;
       }
+    }
+
+    > hr {
+      display: none;
+    }
+
+    p {
+      margin-bottom: 4px;
+    }
+
+    h1, h2, h3, h4, h5, h6 {
+     font-weight: bold;
+     margin-bottom: 0;
+     margin-top: 12px;
+
+     &:first-child {
+       margin-top: 0;
+     }
     }
   }
 
   img {
     max-width: 100%;
+  }
+
+  :global {
+    .ant-collapse-ghost > .ant-collapse-item > .ant-collapse-content > .ant-collapse-content-box {
+      padding-top: 0;
+      padding-bottom: 0;
+      padding-left: 24px;
+    }
+
+    .ant-collapse > .ant-collapse-item > .ant-collapse-header {
+      padding: 12px;
+    }
   }
 }

--- a/src/slots/API/index.tsx
+++ b/src/slots/API/index.tsx
@@ -1,14 +1,17 @@
 import { ZoomInOutlined, ZoomOutOutlined } from '@ant-design/icons';
-import { Popover } from 'antd';
+import { Collapse, Popover } from 'antd';
 import { get } from 'lodash-es';
-import Markdown from 'markdown-to-jsx';
 import React from 'react';
+import Markdown from 'react-markdown';
+import rehypeRaw from 'rehype-raw';
 import { useSnapshot } from 'valtio';
 import { store } from '../../model';
 import { CollapsedIcon } from '../../pages/Example/components/CollapsedIcon';
 import { ExampleTopic } from '../../types';
 import { getDemoInfo } from '../CodeRunner/utils';
 import styles from './index.module.less';
+
+const { Panel } = Collapse;
 
 type APIProps = {
   isPlayground?: boolean;
@@ -33,12 +36,90 @@ export const API = ({
   const demoInfo = getDemoInfo(exampleTopics, topic, example, demo);
   const APIContent = get(demoInfo, ['api', language]);
 
+  /** 从 MD 中解析出最短标题(eg: #、##、###)作为折叠分组条件 */
+  const findShortestHashTag = (lines: string[]) => {
+    const tagLines = lines.filter((line) => line.startsWith('#'));
+    const tagReg = /^#+/g;
+    const tagLengths = tagLines.map((line) => line.match(tagReg)[0].length);
+    return Math.min(...tagLengths);
+  };
+
+  /** 将扁平状态的 MD 解析为嵌套结构 */
+  const renderNestedDom = (content: string) => {
+    if (!content) {
+      return null;
+    }
+    const lines = content.split('\n');
+    const result = [];
+    const tagLengths = findShortestHashTag(lines);
+    const regex = new RegExp(
+      `^${new Array(tagLengths).fill('#').join('')}\\s+([^\\n]*)`,
+    );
+    lines.forEach((line, index) => {
+      if (regex.exec(line)) {
+        const header = regex.exec(line)[1];
+        result.push({
+          start: index,
+          header,
+        });
+      }
+    });
+
+    const MarkdownComponent = ({ content }) => (
+      <Markdown
+        rehypePlugins={[rehypeRaw]}
+        components={{
+          // @ts-expect-error
+          description(props) {
+            const { node, ...rest } = props;
+            return <span style={{ fontSize: 12, color: '#777' }} {...rest} />;
+          },
+        }}
+      >
+        {content}
+      </Markdown>
+    );
+
+    /** 避免无标题的情况内容丢失 */
+    const minStart = get(result, [0, 'start']);
+
+    return (
+      <React.Fragment>
+        {minStart > 0 && (
+          <div className={styles.disorganized}>
+            <MarkdownComponent content={lines.slice(0, minStart).join('\n')} />
+          </div>
+        )}
+        <Collapse bordered={false} defaultActiveKey={[result[0]?.header]} ghost>
+          {result.map((item, index) => {
+            const { start, header } = item;
+            const end =
+              index === result.length - 1
+                ? lines.length
+                : result[index + 1].start;
+            return (
+              <Panel
+                header={<b style={{ lineHeight: '22px' }}>{header}</b>}
+                key={header}
+              >
+                <MarkdownComponent
+                  content={lines.slice(start + 1, end).join('\n')}
+                />
+              </Panel>
+            );
+          })}
+        </Collapse>
+      </React.Fragment>
+    );
+  };
+
   return (
     <div
       className={styles.api}
       style={{ width: state.showAPI ? state.apiContainerWidth : 24 }}
     >
       <div className={styles.header}>
+        <p>API</p>
         <div className={styles.zoom}>
           <ZoomInOutlined
             onClick={() => {
@@ -72,9 +153,9 @@ export const API = ({
       </div>
       <div className={styles.content}>
         {!EMPTY.test(APIContent) ? (
-          <Markdown>{APIContent}</Markdown>
+          renderNestedDom(APIContent)
         ) : (
-          <div style={{ textAlign: 'center' }}>
+          <div style={{ textAlign: 'center', padding: 12 }}>
             <h1>404</h1>
             <p>Sorry, the API you visited does not exist.</p>
           </div>

--- a/src/slots/API/index.tsx
+++ b/src/slots/API/index.tsx
@@ -3,6 +3,7 @@ import { Collapse, Popover } from 'antd';
 import { get } from 'lodash-es';
 import React from 'react';
 import Markdown from 'react-markdown';
+import remarkGfm from 'remark-gfm';
 import rehypeRaw from 'rehype-raw';
 import { useSnapshot } from 'valtio';
 import { store } from '../../model';
@@ -67,12 +68,11 @@ export const API = ({
 
     const MarkdownComponent = ({ content }) => (
       <Markdown
-        rehypePlugins={[rehypeRaw]}
+        rehypePlugins={[rehypeRaw, remarkGfm]}
         components={{
           // @ts-expect-error
           description(props) {
-            const { node, ...rest } = props;
-            return <span style={{ fontSize: 12, color: '#777' }} {...rest} />;
+            return <span style={{ fontSize: 12, color: '#777' }} {...props} />;
           },
         }}
       >
@@ -99,7 +99,9 @@ export const API = ({
                 : result[index + 1].start;
             return (
               <Panel
-                header={<b style={{ lineHeight: '22px' }}>{header}</b>}
+                header={
+                  <b style={{ lineHeight: '22px', fontSize: 16 }}>{header}</b>
+                }
                 key={header}
               >
                 <MarkdownComponent


### PR DESCRIPTION
1. 新增 API 折叠功能，可多层折叠，增强可读性
2. API 解析支持 `<embed src="" />` 模式，兼容之前的API写法
3. `markdown-to-jsx` 替换为 `react-markdown`
4. API 预览宽度默认调整为 420

## 单层嵌套

![image](https://github.com/antvis/dumi-theme-antv/assets/31396322/e883add7-5164-437e-a79c-6b344334702e)


## 多层嵌套

![image](https://github.com/antvis/dumi-theme-antv/assets/31396322/d54249a6-ff3d-41fe-a6d1-d19067019942)

