### PR TITLE
fix: the style error for the too long guide 

### DIFF
--- a/src/slots/ManualContent/index.module.less
+++ b/src/slots/ManualContent/index.module.less
@@ -253,8 +253,8 @@
   float: right;
   font-size: 12px;
   background: #fff;
-  min-height: 100vh;
-
+  max-height: 100vh;
+  overflow: auto;
 
   position: sticky;
   top: 0;

--- a/src/slots/ManualContent/index.module.less
+++ b/src/slots/ManualContent/index.module.less
@@ -253,8 +253,8 @@
   float: right;
   font-size: 12px;
   background: #fff;
-  max-height: 100vh;
-  overflow: hidden;
+  min-height: 100vh;
+
 
   position: sticky;
   top: 0;


### PR DESCRIPTION
![image](https://github.com/antvis/dumi-theme-antv/assets/116412388/c0ff1bc3-a106-4b0e-a6cb-0e6c76696f71)
