### PR TITLE
fix: install hast@2.x

### DIFF
--- a/package.json
+++ b/package.json
@@ -105,6 +105,7 @@
     "@types/classnames": "^2.3.1",
     "@types/fs-extra": "^9.0.13",
     "@types/glob": "^8.0.0",
+    "@types/hast": "^2.3.5",
     "@types/lodash-es": "^4.17.6",
     "@types/node": "^18.11.3",
     "@types/react": "^18.0.21",


### PR DESCRIPTION
修复发包时候遇见的一个类型问题，默认的类型安装的是 3.x，会报错，保持和 dumi 的一致：https://github.com/umijs/dumi/blob/365e5131116f8d222a8bd16dfb95193b736e229f/package.json#L85C21-L85C28