### PR TITLE
fix: Unique Monaco editor path to prevent instance conflicts

### DIFF
--- a/src/slots/CodeEditor/index.tsx
+++ b/src/slots/CodeEditor/index.tsx
@@ -356,7 +356,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
         const code = (spec) => {
           if (!full) return `(${spec})`;
           return `import { Chart } from '@antv/g2';
-          
+
           const chart = new Chart({container:'container'});
 
           chart.options(${spec});
@@ -419,7 +419,7 @@ export const CodeEditor: React.FC<CodeEditorProps> = ({
             language={languageOf(tab)}
             value={valueOf(tab)}
             defaultValue={defaultOf(tab)}
-            path={tab}
+            path={`${tab}_${relativePath || exampleId}`}
             loading={<Loading />}
             options={{
               readOnly: tab === EDITOR_TABS.DATA || tab === EDITOR_TABS.SPEC,


### PR DESCRIPTION
🐛 Bugfix

- [x] Solve the issue and close #2977

### 🔗 Related issue link

https://github.com/antvis/S2/issues/2977

### 📝 Description
Monaco Editor 的模型缓存机制与多实例场景冲突。具体原因如下：
模型路径（Path）重复：
每个 Monaco Editor 实例通过 path 属性标识其模型。
代码中 path={tab} 会导致不同实例的同类型 Tab 共享同一模型（如两个实例的 EDITOR_TABS.JAVASCRIPT 共享模型），引发内容覆盖。

### 🖼️ Screenshot

<!-- Comparison of screenshots before and after changes, it is best to be GIF -->
<!-- 改动前后的截图对比，最好是 GIF -->

| Before | After |
| ------ | ----- |
| ![image](https://github.com/user-attachments/assets/a645d52e-4b92-4271-ba82-8c63edd306c5)  |  ![image](https://github.com/user-attachments/assets/f7501070-44a2-40ac-9c5e-519e7d8e8949)  |
