### PR TITLE
feat: add dead link checker plugin

### DIFF
--- a/example/.dumirc.ts
+++ b/example/.dumirc.ts
@@ -390,6 +390,13 @@ export default defineConfig({
       size: 0.4, // 代码区占比
       playgroundSize: 0.38, // 文档中的代码区占比
     },
+    // 死链检查配置（默认开启）
+    deadLinkChecker: {
+      // 启用功能
+      enable: true,
+      // 是否检查外部链接
+      checkExternalLinks: true,
+    },
   },
   analytics: {
     // google analytics 的 key (GA 4)

--- a/package.json
+++ b/package.json
@@ -103,7 +103,12 @@
     "unist-util-visit": "^4.1.2",
     "uri-parse": "^1.0.0",
     "valtio": "^1.13.2",
-    "video-react": "^0.16.0"
+    "video-react": "^0.16.0",
+    "chalk": "^4.1.2",
+    "cheerio": "^1.0.0-rc.12",
+    "lodash.merge": "^4.6.2",
+    "node-fetch": "^2.6.7",
+    "p-limit": "^3.1.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.8.1",

--- a/package.json
+++ b/package.json
@@ -63,6 +63,8 @@
     "@petercatai/assistant": "^2.0.24",
     "@stackblitz/sdk": "^1.11.0",
     "antd": "^4.24.16",
+    "chalk": "^4.1.2",
+    "cheerio": "^1.0.0-rc.12",
     "classnames": "^2.5.1",
     "codesandbox": "^2.2.3",
     "d3-dsv": "^3.0.1",
@@ -77,6 +79,7 @@
     "lodash-es": "^4.17.21",
     "monaco-editor": "^0.25.2",
     "nprogress": "^0.2.0",
+    "p-limit": "^3.1.0",
     "parse-github-url": "^1.0.3",
     "rc-drawer": "^4.4.3",
     "rc-footer": "^0.6.8",
@@ -103,12 +106,7 @@
     "unist-util-visit": "^4.1.2",
     "uri-parse": "^1.0.0",
     "valtio": "^1.13.2",
-    "video-react": "^0.16.0",
-    "chalk": "^4.1.2",
-    "cheerio": "^1.0.0-rc.12",
-    "lodash.merge": "^4.6.2",
-    "node-fetch": "^2.6.7",
-    "p-limit": "^3.1.0"
+    "video-react": "^0.16.0"
   },
   "devDependencies": {
     "@commitlint/cli": "^17.8.1",

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "insert-css": "^2.0.0",
     "leancloud-storage": "^4.15.2",
     "lodash-es": "^4.17.21",
+    "lodash.merge": "^4.6.2",
     "monaco-editor": "^0.25.2",
     "nprogress": "^0.2.0",
     "p-limit": "^3.1.0",

--- a/src/plugin/deadLinkChecker.ts
+++ b/src/plugin/deadLinkChecker.ts
@@ -1,0 +1,327 @@
+import chalk from 'chalk';
+import * as cheerio from 'cheerio';
+import { IApi } from 'dumi';
+import * as fs from 'fs';
+import * as glob from 'glob';
+import merge from 'lodash.merge';
+import fetch from 'node-fetch';
+import pLimit from 'p-limit';
+import * as path from 'path';
+
+interface DeadLinkOptions {
+  // 构建输出目录，默认是 dist
+  distDir: string;
+  // 检查外部链接，默认是 true
+  checkExternalLinks: boolean;
+  // 忽略的链接，默认是 ['^#', '^mailto:', '^tel:', '^javascript:', '^data:', '.*stackblitz\\.com.*']
+  ignorePatterns: (string | RegExp)[];
+  // 检查的文件扩展名，默认是 ['.html']
+  fileExtensions: string[];
+  // 失败时是否退出，默认是 false
+  failOnError: boolean;
+  // 外部链接超时时间，默认是 10000
+  externalLinkTimeout: number;
+  // 最大并发请求数，默认是 5
+  maxConcurrentRequests: number;
+}
+
+interface DeadLinkConfig extends Omit<DeadLinkOptions, 'ignorePatterns'> {
+  ignorePatterns: RegExp[];
+}
+
+interface LinkInfo {
+  url: string;
+  text: string;
+  sourceFile: string;
+  isExternal: boolean;
+}
+
+interface DeadLink extends LinkInfo {
+  reason: string;
+}
+
+interface CheckResult {
+  totalLinks: number;
+  deadLinks: DeadLink[];
+  success: boolean;
+}
+
+const defaultConfig: DeadLinkOptions = {
+  distDir: 'dist',
+  checkExternalLinks: true,
+  ignorePatterns: ['^#', '^mailto:', '^tel:', '^javascript:', '^data:', '.*stackoverflow\\.com.*'],
+  fileExtensions: ['.html'],
+  failOnError: false,
+  externalLinkTimeout: 10000,
+  maxConcurrentRequests: 5,
+};
+
+/**
+ * 处理配置，转换正则表达式
+ */
+function processConfig(options: DeadLinkOptions): DeadLinkConfig {
+  return {
+    ...options,
+    ignorePatterns: options.ignorePatterns.map((pattern) =>
+      typeof pattern === 'string' ? new RegExp(pattern) : pattern,
+    ),
+  };
+}
+
+/**
+ * 收集HTML文件中的所有链接
+ */
+function collectLinks(htmlFiles: string[], distDir: string): LinkInfo[] {
+  const links: LinkInfo[] = [];
+
+  htmlFiles.forEach((htmlFile) => {
+    const filePath = path.join(distDir, htmlFile);
+    const content = fs.readFileSync(filePath, 'utf-8');
+    const $ = cheerio.load(content);
+
+    $('a').each((_, element) => {
+      const url = $(element).attr('href');
+      if (!url) return;
+
+      links.push({
+        url,
+        text: $(element).text().trim() || '[No text]',
+        sourceFile: htmlFile,
+        isExternal: url.startsWith('http://') || url.startsWith('https://'),
+      });
+    });
+  });
+
+  return links;
+}
+
+/**
+ * 过滤掉被忽略的链接
+ */
+function filterIgnoredLinks(links: LinkInfo[], ignorePatterns: RegExp[]): LinkInfo[] {
+  return links.filter((link) => {
+    return !ignorePatterns.some((pattern) => pattern.test(link.url));
+  });
+}
+
+/**
+ * 检查内部链接
+ */
+function checkInternalLinks(links: LinkInfo[], existingFiles: Set<string>): DeadLink[] {
+  const deadLinks: DeadLink[] = [];
+
+  links.forEach((link) => {
+    if (!link.url.startsWith('/') || link.url.startsWith('//')) return;
+
+    // 移除URL中的锚点部分
+    let normalizedLink = link.url.split('#')[0];
+
+    // 移除URL中的查询参数部分
+    normalizedLink = normalizedLink.split('?')[0];
+
+    if (normalizedLink.endsWith('/')) {
+      normalizedLink += 'index.html';
+    }
+
+    const exists =
+      existingFiles.has(normalizedLink) ||
+      (path.extname(normalizedLink) === '' &&
+        (existingFiles.has(normalizedLink + '/') ||
+          existingFiles.has(normalizedLink + '/index.html') ||
+          existingFiles.has(normalizedLink + '.html')));
+
+    if (!exists) {
+      deadLinks.push({
+        ...link,
+        reason: 'File not found',
+      });
+    }
+  });
+
+  return deadLinks;
+}
+
+/**
+ * 检查外部链接
+ */
+async function checkExternalLinks(links: LinkInfo[], config: DeadLinkConfig): Promise<DeadLink[]> {
+  const deadLinks: DeadLink[] = [];
+  const limit = pLimit(config.maxConcurrentRequests);
+
+  const promises = links.map((link) => {
+    return limit(async () => {
+      try {
+        const controller = new AbortController();
+        const timeoutId = setTimeout(() => controller.abort(), config.externalLinkTimeout);
+
+        const response = await fetch(link.url);
+
+        clearTimeout(timeoutId);
+
+        if (response.status >= 400) {
+          deadLinks.push({
+            ...link,
+            reason: `Status code ${response.status}`,
+          });
+        }
+      } catch (error) {
+        deadLinks.push({
+          ...link,
+          reason: error instanceof Error ? error.message : String(error),
+        });
+      }
+    });
+  });
+
+  await Promise.all(promises);
+
+  return deadLinks;
+}
+
+/**
+ * 执行死链检查
+ */
+async function runCheck(config: DeadLinkConfig): Promise<CheckResult> {
+  const distDir = path.resolve(process.cwd(), config.distDir);
+
+  if (!fs.existsSync(distDir)) {
+    return {
+      totalLinks: 0,
+      deadLinks: [],
+      success: false,
+    };
+  }
+
+  const htmlFiles = glob.sync(`**/*+(${config.fileExtensions.join('|')})`, { cwd: distDir });
+
+  const existingFiles = new Set<string>();
+  glob.sync('**/*', { cwd: distDir, nodir: true }).forEach((file) => {
+    existingFiles.add('/' + file);
+  });
+
+  const allLinks = collectLinks(htmlFiles, distDir);
+  const linksToCheck = filterIgnoredLinks(allLinks, config.ignorePatterns);
+
+  const internalDeadLinks = checkInternalLinks(
+    linksToCheck.filter((link) => !link.isExternal),
+    existingFiles,
+  );
+
+  const externalDeadLinks = config.checkExternalLinks
+    ? await checkExternalLinks(
+        linksToCheck.filter((link) => link.isExternal),
+        config,
+      )
+    : [];
+
+  const deadLinks = [...internalDeadLinks, ...externalDeadLinks];
+
+  return {
+    totalLinks: allLinks.length,
+    deadLinks,
+    success: deadLinks.length === 0,
+  };
+}
+
+/**
+ * 生成死链检查报告并打印到控制台
+ */
+function generateReport(result: CheckResult): void {
+  console.log();
+
+  if (result.deadLinks.length === 0) {
+    console.log(chalk.green(`✓ Check completed: All ${result.totalLinks} links are valid`));
+    console.log();
+    return;
+  }
+
+  const linksByFile = result.deadLinks.reduce((acc, link) => {
+    if (!acc[link.sourceFile]) {
+      acc[link.sourceFile] = [];
+    }
+    acc[link.sourceFile].push(link);
+    return acc;
+  }, {} as Record<string, DeadLink[]>);
+
+  console.log(
+    chalk.yellow(
+      `📊 Found ${result.deadLinks.length}/${result.totalLinks} dead links in ${Object.keys(linksByFile).length} files`,
+    ),
+  );
+
+  Object.entries(linksByFile).forEach(([file, links]) => {
+    console.log();
+    console.log(chalk.yellow(`📄 ${file}:`));
+
+    links.forEach((link) => {
+      console.log(chalk.red(`  ✗ ${link.url}`));
+      console.log(chalk.gray(`    • Text: ${link.text}`));
+      console.log(chalk.gray(`    • Reason: ${link.reason}`));
+    });
+  });
+
+  console.log();
+  console.log(chalk.cyan(`💡 Tip: Please fix these links and run \`npx dumi check-links\` to verify`));
+  console.log(chalk.cyan(`💡 Tip: Don't forget to run \`npm run build\` after fixing the links`));
+  console.log();
+}
+
+/**
+ * dumi 死链检查插件
+ */
+export default (api: IApi) => {
+  // 从 themeConfig 中获取配置
+  const getConfig = (): DeadLinkConfig => {
+    const themeConfig = api.config.themeConfig || {};
+    const userConfig = themeConfig.deadLinkChecker || {};
+
+    // 检查是否禁用
+    if (userConfig.enable === false) {
+      return processConfig({
+        ...defaultConfig,
+        // 设置为空数组，使插件不执行任何检查
+        fileExtensions: [],
+      });
+    }
+
+    // 合并默认配置和用户配置
+    return processConfig(merge({}, defaultConfig, userConfig));
+  };
+
+  const checkLinks = async (onBeforeCheck?: () => void) => {
+    const config = getConfig();
+    // 如果禁用了功能或文件扩展名为空，则跳过检查
+    if (config.fileExtensions.length === 0) {
+      return;
+    }
+
+    onBeforeCheck?.();
+    const result = await runCheck(config);
+    generateReport(result);
+
+    // 只有在发现死链接且配置为失败时退出
+    if (!result.success && config.failOnError) {
+      process.exit(1);
+    } else {
+      process.exit(0);
+    }
+  };
+
+  // 注册命令
+  api.registerCommand({
+    name: 'check-links',
+    fn: async () => {
+      await checkLinks(() => {
+        console.log(chalk.gray('🔍 Checking for dead links...'));
+      });
+    },
+  });
+
+  // build 完成且 html 完成构建之后
+  api.onBuildHtmlComplete(async () => {
+    await checkLinks(() => {
+      console.log(chalk.green('🚀 Build completed.'));
+      console.log(chalk.gray('🔍 Checking for dead links...'));
+    });
+  });
+};

--- a/src/plugin/deadLinkChecker.ts
+++ b/src/plugin/deadLinkChecker.ts
@@ -4,7 +4,6 @@ import { IApi } from 'dumi';
 import * as fs from 'fs';
 import * as glob from 'glob';
 import merge from 'lodash.merge';
-import fetch from 'node-fetch';
 import pLimit from 'p-limit';
 import * as path from 'path';
 

--- a/src/plugin/deadLinkChecker.ts
+++ b/src/plugin/deadLinkChecker.ts
@@ -48,7 +48,7 @@ interface CheckResult {
 }
 
 const defaultConfig: DeadLinkOptions = {
-  enable: true,
+  enable: false,
   distDir: 'dist',
   checkExternalLinks: true,
   ignorePatterns: ['^#', '^mailto:', '^tel:', '^javascript:', '^data:', '.*stackoverflow\\.com.*'],
@@ -57,6 +57,9 @@ const defaultConfig: DeadLinkOptions = {
   externalLinkTimeout: 10000,
   maxConcurrentRequests: 5,
 };
+
+// 在文件顶部添加缓存对象声明
+const tempCache: Record<string, { success: boolean; reason?: string }> = {};
 
 /**
  * 处理配置，转换正则表达式
@@ -150,33 +153,60 @@ async function checkExternalLinks(links: LinkInfo[], config: DeadLinkConfig): Pr
   const deadLinks: DeadLink[] = [];
   const limit = pLimit(config.maxConcurrentRequests);
 
-  const promises = links.map((link) => {
+  // 分离需要检查的链接和已缓存的链接
+  const uncachedLinks: LinkInfo[] = [];
+  links.forEach((link) => {
+    // 检查缓存中是否已有结果
+    if (tempCache[link.url]) {
+      // 使用缓存结果
+      if (!tempCache[link.url].success) {
+        deadLinks.push({
+          ...link,
+          reason: tempCache[link.url].reason || '未知错误',
+        });
+      }
+      console.log(chalk.gray(`  [cached] ${link.url}`));
+    } else {
+      uncachedLinks.push(link);
+    }
+  });
+
+  // 只检查未缓存的链接
+  const promises = uncachedLinks.map((link) => {
     return limit(async () => {
       try {
         const controller = new AbortController();
         const timeoutId = setTimeout(() => controller.abort(), config.externalLinkTimeout);
 
         const response = await fetch(link.url);
-
         clearTimeout(timeoutId);
 
+        // 存入缓存
         if (response.status >= 400) {
+          tempCache[link.url] = {
+            success: false,
+            reason: `Status code ${response.status}`,
+          };
           deadLinks.push({
             ...link,
             reason: `Status code ${response.status}`,
           });
+        } else {
+          tempCache[link.url] = { success: true };
         }
       } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error);
+        // 存入缓存
+        tempCache[link.url] = { success: false, reason };
         deadLinks.push({
           ...link,
-          reason: error instanceof Error ? error.message : String(error),
+          reason,
         });
       }
     });
   });
 
   await Promise.all(promises);
-
   return deadLinks;
 }
 
@@ -278,7 +308,7 @@ export default (api: IApi) => {
     const userConfig = (themeConfig?.deadLinkChecker || {}) as DeadLinkConfig;
 
     // 检查是否禁用
-    if (userConfig.enable === false) {
+    if (!userConfig.enable) {
       return processConfig({
         ...defaultConfig,
         // 设置为空数组，使插件不执行任何检查

--- a/src/plugin/deadLinkChecker.ts
+++ b/src/plugin/deadLinkChecker.ts
@@ -8,6 +8,8 @@ import pLimit from 'p-limit';
 import * as path from 'path';
 
 interface DeadLinkOptions {
+  // 是否开启死链检查，默认是 true
+  enable: boolean;
   // 构建输出目录，默认是 dist
   distDir: string;
   // 检查外部链接，默认是 true
@@ -46,6 +48,7 @@ interface CheckResult {
 }
 
 const defaultConfig: DeadLinkOptions = {
+  enable: true,
   distDir: 'dist',
   checkExternalLinks: true,
   ignorePatterns: ['^#', '^mailto:', '^tel:', '^javascript:', '^data:', '.*stackoverflow\\.com.*'],
@@ -271,8 +274,8 @@ function generateReport(result: CheckResult): void {
 export default (api: IApi) => {
   // 从 themeConfig 中获取配置
   const getConfig = (): DeadLinkConfig => {
-    const themeConfig = api.config.themeConfig || {};
-    const userConfig = themeConfig.deadLinkChecker || {};
+    const themeConfig = (api.config.themeConfig || {}) as any;
+    const userConfig = (themeConfig?.deadLinkChecker || {}) as DeadLinkConfig;
 
     // 检查是否禁用
     if (userConfig.enable === false) {
@@ -295,6 +298,9 @@ export default (api: IApi) => {
     }
 
     onBeforeCheck?.();
+
+    console.log(chalk.gray('🔍 Checking for dead links...'));
+
     const result = await runCheck(config);
     generateReport(result);
 
@@ -306,21 +312,5 @@ export default (api: IApi) => {
     }
   };
 
-  // 注册命令
-  api.registerCommand({
-    name: 'check-links',
-    fn: async () => {
-      await checkLinks(() => {
-        console.log(chalk.gray('🔍 Checking for dead links...'));
-      });
-    },
-  });
-
-  // build 完成且 html 完成构建之后
-  api.onBuildHtmlComplete(async () => {
-    await checkLinks(() => {
-      console.log(chalk.green('🚀 Build completed.'));
-      console.log(chalk.gray('🔍 Checking for dead links...'));
-    });
-  });
+  return checkLinks;
 };

--- a/src/plugin/examples.ts
+++ b/src/plugin/examples.ts
@@ -112,5 +112,5 @@ export const getExamplesPageTopics = (exampleTopics: ExampleTopic[], showAPIDoc:
 export function getExamplePaths() {
   const exampleTopicPaths = glob.sync(`${examplesBaseDir}/*/*`);
   const paths = exampleTopicPaths.map((p) => p.replace(process.cwd(), ''));
-  return [...paths, ...paths.map((p) => `/zh${p}`), ...paths.map((p) => `/en${p}`)];
+  return [...paths, ...paths.map((p) => `/en${p}`)];
 }

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -2,6 +2,7 @@ import type { IApi } from 'dumi';
 import { winPath } from 'dumi/plugin-utils';
 import * as path from 'path';
 import { AntVReactTechStack } from './antVReactTechStack';
+import deadLinkCheckerPlugin from './deadLinkChecker';
 import { getExamplePaths, getExamplesPageTopics } from './examples';
 import rehypeObservable from './rehypeObservable';
 import remarkFeedback from './remarkFeedback';
@@ -133,12 +134,6 @@ export default function ThemeAntVContextWrapper() {
         path: 'en',
         file: `${PAGES_DIR}/Index`,
       },
-      {
-        id: 'dumi-theme-antv-homepage-zh',
-        absPath: '/zh/',
-        path: 'zh',
-        file: `${PAGES_DIR}/Index`,
-      },
       // Examples gallery page.
       {
         id: 'dumi-theme-antv-example-list-zh',
@@ -148,8 +143,8 @@ export default function ThemeAntVContextWrapper() {
       },
       {
         id: 'dumi-theme-antv-example-list-lang',
-        absPath: '/:language/examples',
-        path: ':language/examples',
+        absPath: '/en/examples',
+        path: 'en/examples',
         file: `${PAGES_DIR}/Examples`,
       },
       // single example preview page.
@@ -161,8 +156,8 @@ export default function ThemeAntVContextWrapper() {
       },
       {
         id: 'dumi-theme-antv-single-example-lang',
-        absPath: '/:language/examples/:topic/:example',
-        path: ':language/examples/:topic/:example',
+        absPath: '/en/examples/:topic/:example',
+        path: 'en/examples/:topic/:example',
         file: `${PAGES_DIR}/Example`,
       },
     ];
@@ -189,4 +184,7 @@ export default function ThemeAntVContextWrapper() {
 
   // extends dumi internal tech stack, for customize previewer props
   api.registerTechStack(() => new AntVReactTechStack());
+
+  // check dead links(only for production)
+  deadLinkCheckerPlugin(api);
 };

--- a/src/plugin/index.ts
+++ b/src/plugin/index.ts
@@ -1,3 +1,4 @@
+import chalk from 'chalk';
 import type { IApi } from 'dumi';
 import { winPath } from 'dumi/plugin-utils';
 import * as path from 'path';
@@ -186,5 +187,18 @@ export default function ThemeAntVContextWrapper() {
   api.registerTechStack(() => new AntVReactTechStack());
 
   // check dead links(only for production)
-  deadLinkCheckerPlugin(api);
+  const checkLinks = deadLinkCheckerPlugin(api);
+
+  // 注册命令
+  api.registerCommand({
+    name: 'check-links',
+    fn: async () => await checkLinks(),
+  });
+
+  // build 完成且 html 完成构建之后
+  api.onBuildHtmlComplete(async () => {
+    await checkLinks(() => {
+      console.log(chalk.green('🚀 Build completed.'));
+    });
+  });
 };


### PR DESCRIPTION
死链检查插件，可以自动检测文档中的无效链接。该插件会在文档构建完成后自动执行，也可以通过命令行手动触发检查。

在项目的 `.dumirc.ts` 文件中，可以通过 `themeConfig.deadLinkChecker` 进行配置：

<img width="885" alt="image" src="https://github.com/user-attachments/assets/c75cdcb2-9ff9-4f57-aa23-2b36dedb5941" />

在项目的 `.dumirc.ts` 中添加配置（默认开启）

<img width="562" alt="image" src="https://github.com/user-attachments/assets/9177ada0-258b-4351-b4e7-9e5aef411925" />

#### 效果

<img width="809" alt="Cursor 2025-03-24 17 19 45" src="https://github.com/user-attachments/assets/1336f647-f28b-4022-8709-dda5270781aa" />

<img width="864" alt="Cursor 2025-03-24 17 20 52" src="https://github.com/user-attachments/assets/d55e79fa-492e-4577-867d-77b1d401e45d" />
