### PR TITLE
feat: Preview 模式下指定 DOM 容器

### DIFF
--- a/example/docs/manual/codeblock.md
+++ b/example/docs/manual/codeblock.md
@@ -173,3 +173,53 @@ globalCard('world');
   });
 })();
 ```
+
+## G2 autoMount
+
+```js | ob { autoMount: true  }
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  theme: 'classic',
+});
+
+chart
+  .interval()
+  .data([
+    { genre: 'Sports', sold: 275 },
+    { genre: 'Strategy', sold: 115 },
+    { genre: 'Action', sold: 120 },
+    { genre: 'Shooter', sold: 350 },
+    { genre: 'Other', sold: 150 },
+  ])
+  .encode('x', 'genre')
+  .encode('y', 'sold');
+
+chart.render();
+```
+
+## G2 autoMount & unpin
+
+```js | ob { pin: false, autoMount: true  }
+import { Chart } from '@antv/g2';
+
+const chart = new Chart({
+  container: 'container',
+  theme: 'classic',
+});
+
+chart
+  .interval()
+  .data([
+    { genre: 'Sports', sold: 275 },
+    { genre: 'Strategy', sold: 115 },
+    { genre: 'Action', sold: 120 },
+    { genre: 'Shooter', sold: 350 },
+    { genre: 'Other', sold: 150 },
+  ])
+  .encode('x', 'genre')
+  .encode('y', 'sold');
+
+chart.render();
+```

--- a/example/package.json
+++ b/example/package.json
@@ -13,7 +13,7 @@
   "dependencies": {
     "@antv/g2": "^5.2.7",
     "d3-regression": "^1.3.10",
-    "dumi": "^2.4.13"
+    "dumi": "2.4.18"
   },
   "devDependencies": {
     "gh-pages": "^4.0.0",


### PR DESCRIPTION
<img width="1481" alt="image" src="https://github.com/user-attachments/assets/ed4873ca-86b6-4d1b-b919-70990742c513" />

支持以下写法：

```
```js | ob { autoMount: true  }
import { Chart } from '@antv/g2';

const chart = new Chart({
  container: 'container',
  theme: 'classic',
});

chart
  .interval()
  .data([
    { genre: 'Sports', sold: 275 },
    { genre: 'Strategy', sold: 115 },
    { genre: 'Action', sold: 120 },
    { genre: 'Shooter', sold: 350 },
    { genre: 'Other', sold: 150 },
  ])
  .encode('x', 'genre')
  .encode('y', 'sold');

chart.render();
```
```