### PR TITLE
feat: 新增隐藏左侧菜单参数

### DIFF
--- a/example/.dumirc.ts
+++ b/example/.dumirc.ts
@@ -77,6 +77,7 @@ export default defineConfig({
           zh: '教程',
           en: 'Tutorials',
         },
+        sidebar: false,
         order: 2,
       },
       {

--- a/src/slots/ManualContent/index.tsx
+++ b/src/slots/ManualContent/index.tsx
@@ -1,7 +1,8 @@
 import { Layout } from 'antd';
-import { useRouteMeta } from 'dumi';
+import { useLocation, useRouteMeta, useSiteData } from 'dumi';
 import React, { type PropsWithChildren } from 'react';
 import CommonHelmet from '../../common/CommonHelmet';
+import { getNavCategory } from '../Header/utils';
 import styles from './index.module.less';
 import { Main } from './Main';
 import { Sidebar } from './Sidebar';
@@ -9,11 +10,26 @@ import { Sidebar } from './Sidebar';
 export const ManualContent: React.FC<PropsWithChildren> = ({ children }) => {
   const meta = useRouteMeta();
   const { title, description } = meta.frontmatter;
+  const { themeConfig } = useSiteData();
+  const { navs } = themeConfig;
+  const { pathname } = useLocation();
+
+  // 获取当前路径对应的导航分类
+  const currentCategory = getNavCategory(pathname);
+
+  // 查找匹配的导航配置
+  const currentNav = navs.find((nav) => {
+    if (!nav.slug) return false;
+    const navCategory = getNavCategory(nav.slug);
+    return navCategory === currentCategory;
+  });
+
+  const shouldShowSidebar = currentNav?.sidebar !== false;
 
   return (
-    <Layout hasSider className={styles.layout}>
+    <Layout hasSider={shouldShowSidebar} className={styles.layout}>
       <CommonHelmet title={title} description={description} />
-      <Sidebar />
+      {shouldShowSidebar && <Sidebar />}
       <Main>{children}</Main>
     </Layout>
   );


### PR DESCRIPTION
- 配置方式
```
      {
        slug: 'docs/manual',
        title: {
          zh: '教程',
          en: 'Tutorials',
        },
        sidebar: false,
        order: 2,
      },
```
- 效果
![image](https://github.com/user-attachments/assets/004d77de-ef94-437d-a137-8cd0844bfcea)
