### PR TITLE
fix: 修正 less 混入函数 .container1400、.contentReset 调用时添加括号

### DIFF
--- a/src/pages/Examples/index.module.less
+++ b/src/pages/Examples/index.module.less
@@ -232,10 +232,10 @@
   }
 
   .content {
-    .contentReset;
+    .contentReset();
 
     > div {
-      .contentReset;
+      .contentReset();
     }
   }
 }

--- a/src/pages/Index/components/Cases/index.module.less
+++ b/src/pages/Index/components/Cases/index.module.less
@@ -9,7 +9,7 @@
   background: rgba(250, 251, 252, 1);
 
   .slider {
-    .container1440;
+    .container1440();
   }
 
   .appWrapper {

--- a/src/pages/Index/components/Companies/index.module.less
+++ b/src/pages/Index/components/Companies/index.module.less
@@ -13,7 +13,7 @@
     height: 100%;
     margin-bottom: 5%;
     position: relative;
-    .container1440;
+    .container1440();
     padding-left: 4.5%;
   }
 

--- a/src/pages/Index/components/Detail/index.module.less
+++ b/src/pages/Index/components/Detail/index.module.less
@@ -9,7 +9,7 @@
   overflow: hidden;
 
   .content {
-    .container1440;
+    .container1440();
     height: 100%;
     position: relative;
   }

--- a/src/pages/Index/components/Features/index.module.less
+++ b/src/pages/Index/components/Features/index.module.less
@@ -16,7 +16,7 @@
     height: 100%;
     margin-left: 4.2%;
     position: relative;
-    .container1440;
+    .container1440();
   }
 
   .title {

--- a/src/slots/Banner/index.module.less
+++ b/src/slots/Banner/index.module.less
@@ -9,7 +9,7 @@
   overflow: hidden;
 
   .content {
-    .container1440;
+    .container1440();
     height: 100%;
     position: relative;
   }

--- a/src/slots/Footer/index.module.less
+++ b/src/slots/Footer/index.module.less
@@ -5,7 +5,7 @@
 
   :global(.rc-footer-container),
   :global(.rc-footer-bottom-container) {
-    .container1440;
+    .container1440();
   }
 
   :global(.rc-footer-bottom-container) {

--- a/src/slots/Header/Products/Product.module.less
+++ b/src/slots/Header/Products/Product.module.less
@@ -20,7 +20,7 @@
   pointer-events: none;
 
   .container {
-    .container1440;
+    .container1440();
   }
 
   &.show {

--- a/src/slots/Header/index.module.less
+++ b/src/slots/Header/index.module.less
@@ -39,7 +39,7 @@
     margin-bottom: -@nav-height;
 
     .container {
-      .container1440;
+      .container1440();
     }
   }
 


### PR DESCRIPTION
> 背景：

1. dumi-theme-antv 服务启动有一些警告

<img width="2383" height="1300" alt="image" src="https://github.com/user-attachments/assets/730a1abf-2fdb-41f4-bd76-44be4f79ece6" />

2. 在参与其余仓库贡献时有消费该包，报出了一些警告

<img width="2560" height="1415" alt="image" src="https://github.com/user-attachments/assets/3707803a-3b91-4ef3-a945-e5e49022476e" />


> 调研

less 混入函数是支持加括号或不加括号的，最好是加括号！

> 修改后，站点样式加载正常，无告警。
<img width="2940" height="1666" alt="image" src="https://github.com/user-attachments/assets/ca1f5e89-f741-4419-b986-824861343f83" />
<img width="2940" height="1666" alt="image" src="https://github.com/user-attachments/assets/1d011197-dc02-4f8b-9c2a-2a21483da4b0" />
